### PR TITLE
require: bump django-filter to 2.0.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 dj-database-url==0.5.0
 Django==2.1.2
-django-filter==1.1.0
+django-filter==2.0.0
 django-heroku==0.3.1
 django-widget-tweaks==1.4.2
 djangorestframework==3.8.2


### PR DESCRIPTION
Solves the import error
https://github.com/carltongibson/django-filter/issues/956

Signed-off-by: Dimid Duchovny <dimidd@gmail.com>