### PR TITLE
Feature/Add Dockerfile

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,5 @@
+*
+!app/
+!data/
+!tests/
+!requirements.txt

--- a/.dockerignore
+++ b/.dockerignore
@@ -2,4 +2,5 @@
 !app/
 !data/
 !tests/
+!tools/
 !requirements.txt

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,5 +1,7 @@
 *
 !app/
+app/staticfiles/
+app/db.sqlite3
 !data/
 !tests/
 !tools/

--- a/.gitignore
+++ b/.gitignore
@@ -196,3 +196,6 @@ pip-selfcheck.json
 
 # ignore db to avoid merge conflicts
 *.sqlite3
+
+# ignore django generated static files
+app/staticfiles/

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,4 @@ python:
 install:
   - pip install -r requirements.txt
 script:
-  - python app/manage.py migrate
-  - python app/manage.py collectstatic
-  - python app/manage.py test server.tests
+  - tools/ci.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,4 +10,7 @@ COPY . /doccano
 
 WORKDIR /doccano
 
+ENV DEBUG="True"
+ENV SECRET_KEY="change-me-in-production"
+
 CMD ["/venv/bin/gunicorn", "--bind=0.0.0.0:80", "--workers=2", "--pythonpath=app", "app.wsgi"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,5 +11,9 @@ WORKDIR /doccano
 
 ENV DEBUG="True"
 ENV SECRET_KEY="change-me-in-production"
+ENV BIND="0.0.0.0:80"
+ENV WORKERS="2"
 
-CMD ["gunicorn", "--bind=0.0.0.0:80", "--workers=2", "--pythonpath=app", "app.wsgi"]
+EXPOSE 80
+
+CMD ["/doccano/tools/run.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,6 +10,10 @@ COPY . /doccano
 
 WORKDIR /doccano
 
+RUN ["/venv/bin/python", "app/manage.py", "migrate"]
+RUN ["/venv/bin/python", "app/manage.py", "collectstatic"]
+RUN ["/venv/bin/python", "app/manage.py", "test", "server.tests"]
+
 ENV DEBUG="True"
 ENV SECRET_KEY="change-me-in-production"
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,18 +3,13 @@ ARG PYTHON_VERSION="3.6"
 FROM python:${PYTHON_VERSION}
 
 COPY requirements.txt /
-RUN python -m venv /venv \
- && /venv/bin/pip install --no-cache-dir -r /requirements.txt
+RUN pip install --no-cache-dir -r /requirements.txt
 
 COPY . /doccano
 
 WORKDIR /doccano
 
-RUN ["/venv/bin/python", "app/manage.py", "migrate"]
-RUN ["/venv/bin/python", "app/manage.py", "collectstatic"]
-RUN ["/venv/bin/python", "app/manage.py", "test", "server.tests"]
-
 ENV DEBUG="True"
 ENV SECRET_KEY="change-me-in-production"
 
-CMD ["/venv/bin/gunicorn", "--bind=0.0.0.0:80", "--workers=2", "--pythonpath=app", "app.wsgi"]
+CMD ["gunicorn", "--bind=0.0.0.0:80", "--workers=2", "--pythonpath=app", "app.wsgi"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,13 @@
+ARG PYTHON_VERSION="3.6"
+
+FROM python:${PYTHON_VERSION}
+
+COPY requirements.txt /
+RUN python -m venv /venv \
+ && /venv/bin/pip install --no-cache-dir -r /requirements.txt
+
+COPY . /doccano
+
+WORKDIR /doccano
+
+CMD ["/venv/bin/gunicorn", "--bind=0.0.0.0:80", "--workers=2", "--pythonpath=app", "app.wsgi"]

--- a/app/app/settings.py
+++ b/app/app/settings.py
@@ -23,7 +23,9 @@ BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 # See https://docs.djangoproject.com/en/2.0/howto/deployment/checklist/
 
 # SECURITY WARNING: keep the secret key used in production secret!
-SECRET_KEY = 'v8sk33sy82!uw3ty=!jjv5vp7=s2phrzw(m(hrn^f7e_#1h2al'
+SECRET_KEY = os.environ.get(
+    'SECRET_KEY',
+    'v8sk33sy82!uw3ty=!jjv5vp7=s2phrzw(m(hrn^f7e_#1h2al')
 
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = True

--- a/tools/ci.sh
+++ b/tools/ci.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+
+set -o errexit
+
+python app/manage.py migrate
+python app/manage.py collectstatic
+python app/manage.py test server.tests

--- a/tools/run.sh
+++ b/tools/run.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+
+set -o errexit
+
+if [[ ! -d "app/staticfiles" ]]; then python app/manage.py collectstatic --noinput; fi
+
+python app/manage.py migrate
+gunicorn --bind="${BIND:-127.0.0.1:8000}" --workers="${WORKERS:-1}" --pythonpath=app app.wsgi


### PR DESCRIPTION
As per https://github.com/chakki-works/doccano/projects/2#card-16406087, this change adds a Dockerfile for the project.

The Python distribution used by the image can be specified via a build-time argument. This enables us in the future to for example run the tests on a wide variety of Python versions.

In the future, the Dockerfile could be extended to for example leverage multi-stage builds. In this case, the first stage could run tests, linter, and so forth and then create a wheel or similar artifact via setuptools. A second stage in the build can then only include a minimal set of dependencies to install and run the artifact (e.g. using python-slim as a base image).