### PR TITLE
Feature/Add Azure deployment automation

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,15 @@ Final demo is one of the sequence to sequence tasks, machine translation. Since 
 
 ![Machine Translation](./docs/translation.gif)
 
+## Deployment
+
+### Azure
+
+Doccano can be deployed to Azure ([Web App for Containers](https://azure.microsoft.com/en-us/services/app-service/containers/) +
+[PostgreSQL database](https://azure.microsoft.com/en-us/services/postgresql/)) by clicking on the button below:
+
+[![Deploy to Azure](https://azuredeploy.net/deploybutton.svg)](https://portal.azure.com/#create/Microsoft.Template/uri/https%3A%2F%2Fraw.githubusercontent.com%2Fchakki-works%2Fdoccano%2Fmaster%2Fazuredeploy.json)
+
 ## Features
 
 * Collaborative annotation

--- a/app/server/management/commands/create_admin.py
+++ b/app/server/management/commands/create_admin.py
@@ -1,0 +1,27 @@
+from django.contrib.auth.management.commands import createsuperuser
+from django.core.management import CommandError
+
+
+class Command(createsuperuser.Command):
+    help = 'Non-interactively create an admin user'
+
+    def add_arguments(self, parser):
+        super(Command, self).add_arguments(parser)
+        parser.add_argument('--password', default=None,
+                            help='The password for the admin.')
+
+    def handle(self, *args, **options):
+        password = options.get('password')
+        username = options.get('username')
+
+        if password and not username:
+            raise CommandError('--username is required if specifying --password')
+
+        super(Command, self).handle(*args, **options)
+
+        if password:
+            database = options.get('database')
+            db = self.UserModel._default_manager.db_manager(database)
+            user = db.get(username=username)
+            user.set_password(password)
+            user.save()

--- a/app/server/management/commands/wait_for_db.py
+++ b/app/server/management/commands/wait_for_db.py
@@ -1,0 +1,35 @@
+import sys
+import time
+
+from django.db import connection
+from django.db.utils import OperationalError
+from django.core.management.base import BaseCommand
+
+
+class Command(BaseCommand):
+    help = 'Blocks until the database is available'
+
+    def add_arguments(self, parser):
+        parser.add_argument('--poll_seconds', type=float, default=3)
+        parser.add_argument('--max_retries', type=int, default=60)
+
+    def handle(self, *args, **options):
+        max_retries = options['max_retries']
+        poll_seconds = options['poll_seconds']
+
+        for retry in range(max_retries):
+            try:
+                connection.ensure_connection()
+            except OperationalError as ex:
+                self.stdout.write(
+                    'Database unavailable on attempt {attempt}/{max_retries}:'
+                    ' {error}'.format(
+                        attempt=retry + 1,
+                        max_retries=max_retries,
+                        error=ex))
+                time.sleep(poll_seconds)
+            else:
+                break
+        else:
+            self.stdout.write(self.style.ERROR('Database unavailable'))
+            sys.exit(1)

--- a/azuredeploy.json
+++ b/azuredeploy.json
@@ -101,7 +101,25 @@
     "databaseVersion": "9.6",
     "databaseServerName": "[concat(parameters('appName'),'-state')]",
     "setupScriptName": "[concat(parameters('appName'),'-setup')]",
-    "appServicePlanName": "[concat(parameters('appName'),'-hosting')]"
+    "appServicePlanName": "[concat(parameters('appName'),'-hosting')]",
+    "env": [
+      {
+        "name": "WEBSITES_ENABLE_APP_SERVICE_STORAGE",
+        "value": "false"
+      },
+      {
+        "name": "DEBUG",
+        "value": "False"
+      },
+      {
+        "name": "SECRET_KEY",
+        "value": "[parameters('secretKey')]"
+      },
+      {
+        "name": "DATABASE_URL",
+        "value": "[variables('databaseConnectionString')]"
+      }
+    ]
   },
   "resources": [
     {
@@ -181,20 +199,7 @@
                 "[parameters('adminContactEmail')]",
                 "[parameters('adminPassword')]"
               ],
-              "environmentVariables": [
-                {
-                  "name": "DEBUG",
-                  "value": "False"
-                },
-                {
-                  "name": "SECRET_KEY",
-                  "value": "[parameters('secretKey')]"
-                },
-                {
-                  "name": "DATABASE_URL",
-                  "value": "[variables('databaseConnectionString')]"
-                }
-              ],
+              "environmentVariables": "[variables('env')]",
               "resources": {
                 "requests": {
                   "cpu": "1",
@@ -226,24 +231,7 @@
         "siteConfig": {
           "linuxFxVersion": "[concat('DOCKER|', parameters('dockerImageName'))]",
           "alwaysOn": true,
-          "appSettings": [
-            {
-              "name": "WEBSITES_ENABLE_APP_SERVICE_STORAGE",
-              "value": "false"
-            },
-            {
-              "name": "DEBUG",
-              "value": "False"
-            },
-            {
-              "name": "SECRET_KEY",
-              "value": "[parameters('secretKey')]"
-            },
-            {
-              "name": "DATABASE_URL",
-              "value": "[variables('databaseConnectionString')]"
-            }
-          ]
+          "appSettings": "[variables('env')]"
         },
         "serverFarmId": "[resourceId('Microsoft.Web/serverfarms', variables('appServicePlanName'))]"
       }

--- a/azuredeploy.json
+++ b/azuredeploy.json
@@ -1,0 +1,197 @@
+{
+  "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+  "contentVersion": "1.0.0.0",
+  "parameters": {
+    "appName":{
+      "type": "string",
+      "minLength":  1,
+      "metadata": {
+        "description": "The name for the webapp. Must be globally unique."
+      }
+    },
+    "secretKey":{
+      "type": "securestring",
+      "minLength":  16,
+      "metadata": {
+        "description": "The value to use as the Django secret key."
+      }
+    },
+    "adminUserName":{
+      "type": "string",
+      "minLength":  1,
+      "metadata": {
+        "description": "The user name for the Postgres administrator"
+      }
+    },
+    "adminPassword":{
+      "type": "securestring",
+      "minLength": 16,
+      "metadata": {
+        "description": "The password for the Postgres administrator"
+      }
+    },
+    "appServiceSku": {
+      "type": "string",
+      "defaultValue": "B2",
+      "allowedValues": [
+        "B1",
+        "B2",
+        "B3",
+        "S1",
+        "S2",
+        "S3"
+      ],
+      "metadata": {
+        "description": "The SKU of the webapp hosting tier."
+      }
+    },
+    "databaseCores": {
+      "type": "int",
+      "defaultValue": 2,
+      "allowedValues": [
+        2,
+        4,
+        8,
+        16,
+        32,
+        64
+      ],
+      "metadata": {
+        "description": "The number of vCores to provision for the PostgreSQL server."
+      }
+    },
+    "databaseSize": {
+      "type": "int",
+      "minValue": 51200,
+      "defaultValue": 51200,
+      "metadata": {
+        "description": "The storage capacity to provision for the PostgreSQL server."
+      }
+    },
+    "databaseName": {
+      "type": "string",
+      "minLength": 1,
+      "defaultValue": "doccano",
+      "metadata": {
+        "description": "The name of the database to provision on the PostgreSQL server."
+      }
+    },
+    "dockerImageName": {
+      "type": "string",
+      "minLength": 1,
+      "defaultValue": "cwolff/doccano:latest",
+      "metadata": {
+        "description": "The Docker image to deploy."
+      }
+    }
+  },
+  "variables": {
+    "location": "[resourceGroup().location]",
+    "databaseSkuTier": "GeneralPurpose",
+    "databaseSkuFamily": "Gen5",
+    "databaseSkuName": "[concat('GP_', variables('databaseSkuFamily'), '_', parameters('databaseCores'))]",
+    "databaseConnectionString": "[concat('pgsql://', parameters('adminUserName'), '@', variables('databaseServerName'), ':', parameters('adminPassword'), '@', variables('databaseServerName'), '.postgres.database.azure.com:5432/', parameters('databaseName'))]",
+    "databaseVersion": "9.6",
+    "databaseServerName": "[concat(parameters('appName'),'-state')]",
+    "appServicePlanName": "[concat(parameters('appName'),'-hosting')]"
+  },
+  "resources": [
+    {
+      "apiVersion": "2017-08-01",
+      "type": "Microsoft.Web/serverfarms",
+      "kind": "linux",
+      "name": "[variables('appServicePlanName')]",
+      "location": "[variables('location')]",
+      "properties": {
+        "reserved": true
+      },
+      "dependsOn": [],
+      "sku": {
+        "name": "[parameters('appServiceSku')]"
+      }
+    },
+    {
+      "apiVersion": "2017-12-01",
+      "type": "Microsoft.DBforPostgreSQL/servers",
+      "location": "[variables('location')]",
+      "name": "[variables('databaseServerName')]",
+      "sku": {
+        "name": "[variables('databaseSkuName')]",
+        "tier": "[variables('databaseSkuTier')]",
+        "family": "[variables('databaseSkuFamily')]",
+        "capacity": "[parameters('databaseCores')]",
+        "size": "[parameters('databaseSize')]"
+      },
+      "properties": {
+        "version": "[variables('databaseVersion')]",
+        "administratorLogin": "[parameters('adminUserName')]",
+        "administratorLoginPassword": "[parameters('adminPassword')]",
+        "storageMB": "[parameters('databaseSize')]"
+      },
+      "resources": [
+        {
+          "name": "allowAzure",
+          "type": "firewallrules",
+          "apiVersion": "2017-12-01",
+          "location": "[variables('location')]",
+          "properties": {
+            "startIpAddress": "0.0.0.0",
+            "endIpAddress": "0.0.0.0"
+          },
+          "dependsOn": [
+            "[resourceId('Microsoft.DBforPostgreSQL/servers/', variables('databaseServerName'))]"
+          ]
+        },
+        {
+          "name": "[parameters('databaseName')]",
+          "type": "databases",
+          "apiVersion": "2017-12-01",
+          "properties": {
+            "charset": "utf8",
+            "collation": "English_United States.1252"
+          },
+          "dependsOn": [
+            "[resourceId('Microsoft.DBforPostgreSQL/servers/', variables('databaseServerName'))]"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "Microsoft.Web/sites",
+      "apiVersion": "2016-08-01",
+      "name": "[parameters('appName')]",
+      "kind": "app,linux,container",
+      "location": "[variables('location')]",
+      "dependsOn": [
+        "[resourceId('Microsoft.DBforPostgreSQL/servers/', variables('databaseServerName'))]",
+        "[resourceId('Microsoft.Web/serverfarms', variables('appServicePlanName'))]"
+      ],
+      "properties": {
+        "name": "[parameters('appName')]",
+        "siteConfig": {
+          "linuxFxVersion": "[concat('DOCKER|', parameters('dockerImageName'))]",
+          "alwaysOn": true,
+          "appSettings": [
+            {
+              "name": "WEBSITES_ENABLE_APP_SERVICE_STORAGE",
+              "value": "false"
+            },
+            {
+              "name": "DEBUG",
+              "value": "False"
+            },
+            {
+              "name": "SECRET_KEY",
+              "value": "[parameters('secretKey')]"
+            },
+            {
+              "name": "DATABASE_URL",
+              "value": "[variables('databaseConnectionString')]"
+            }
+          ]
+        },
+        "serverFarmId": "[resourceId('Microsoft.Web/serverfarms', variables('appServicePlanName'))]"
+      }
+    }
+  ]
+}

--- a/azuredeploy.json
+++ b/azuredeploy.json
@@ -20,14 +20,21 @@
       "type": "string",
       "minLength":  1,
       "metadata": {
-        "description": "The user name for the Postgres administrator"
+        "description": "The user name for the admin account."
+      }
+    },
+    "adminContactEmail":{
+      "type": "string",
+      "minLength":  1,
+      "metadata": {
+        "description": "The contact email address for the admin account."
       }
     },
     "adminPassword":{
       "type": "securestring",
       "minLength": 16,
       "metadata": {
-        "description": "The password for the Postgres administrator"
+        "description": "The password for the admin account."
       }
     },
     "appServiceSku": {
@@ -93,6 +100,7 @@
     "databaseConnectionString": "[concat('pgsql://', parameters('adminUserName'), '@', variables('databaseServerName'), ':', parameters('adminPassword'), '@', variables('databaseServerName'), '.postgres.database.azure.com:5432/', parameters('databaseName'))]",
     "databaseVersion": "9.6",
     "databaseServerName": "[concat(parameters('appName'),'-state')]",
+    "setupScriptName": "[concat(parameters('appName'),'-setup')]",
     "appServicePlanName": "[concat(parameters('appName'),'-hosting')]"
   },
   "resources": [
@@ -154,6 +162,53 @@
             "[resourceId('Microsoft.DBforPostgreSQL/servers/', variables('databaseServerName'))]"
           ]
         }
+      ]
+    },
+    {
+      "name": "[variables('setupScriptName')]",
+      "type": "Microsoft.ContainerInstance/containerGroups",
+      "apiVersion": "2018-10-01",
+      "location": "[variables('location')]",
+      "properties": {
+        "containers": [
+          {
+            "name": "createadmin",
+            "properties": {
+              "image": "[parameters('dockerImageName')]",
+              "command": [
+                "tools/create-admin.sh",
+                "[parameters('adminUserName')]",
+                "[parameters('adminContactEmail')]",
+                "[parameters('adminPassword')]"
+              ],
+              "environmentVariables": [
+                {
+                  "name": "DEBUG",
+                  "value": "False"
+                },
+                {
+                  "name": "SECRET_KEY",
+                  "value": "[parameters('secretKey')]"
+                },
+                {
+                  "name": "DATABASE_URL",
+                  "value": "[variables('databaseConnectionString')]"
+                }
+              ],
+              "resources": {
+                "requests": {
+                  "cpu": "1",
+                  "memoryInGb": "1.5"
+                }
+              }
+            }
+          }
+        ],
+        "osType": "Linux",
+        "restartPolicy": "Never"
+      },
+      "dependsOn": [
+        "[resourceId('Microsoft.DBforPostgreSQL/servers/', variables('databaseServerName'))]"
       ]
     },
     {

--- a/tools/create-admin.sh
+++ b/tools/create-admin.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+
+if [[ "$#" -ne 3 ]]; then echo "Usage: $0 <username> <email> <password>" >&2; exit 1; fi
+
+set -o errexit
+
+python app/manage.py wait_for_db
+python app/manage.py migrate
+python app/manage.py create_admin --noinput --username="$1" --email="$2" --password="$3"

--- a/tools/run.sh
+++ b/tools/run.sh
@@ -4,5 +4,6 @@ set -o errexit
 
 if [[ ! -d "app/staticfiles" ]]; then python app/manage.py collectstatic --noinput; fi
 
+python app/manage.py wait_for_db
 python app/manage.py migrate
 gunicorn --bind="${BIND:-127.0.0.1:8000}" --workers="${WORKERS:-1}" --pythonpath=app app.wsgi


### PR DESCRIPTION
Currently the application can easily be deployed to Heroku via the Procfile. This change adds an [ARM template](https://docs.microsoft.com/en-us/azure/azure-resource-manager/resource-group-overview) to additionally easily deploy the application to Azure.

To make management of the application as straight forward as possible, the ARM template leverages PaaS solutions: the Django application is deployed via the Docker container to a [Web App for Containers](https://azure.microsoft.com/en-us/services/app-service/containers/) and the app's data storage is a [managed PostgreSQL](https://azure.microsoft.com/en-us/services/postgresql/) instance.

For additional security, the PostgreSQL database is configured to only allow connections from other Azure IPs. If someone wishes to connect to the database manually, e.g. via pgadmin, the client's IP must be white-listed in the database server's firewall ([instructions](https://docs.microsoft.com/en-us/azure/postgresql/concepts-firewall-rules#connecting-from-the-internet)).

Given that the resources are deployed asynchronously by ARM, sometimes the web app may be provisioned before the database is set up or before the database server's firewall is correctly set up. To prevent race conditions, this change includes a Django management script that makes the application wait until the database is available before starting up. This script will also be useful in other contexts such as using an external database linked to the application in docker-compose or kubernetes.