### PR TITLE
Feature/Add social login via Github and Active Directory

### DIFF
--- a/app/app/settings.py
+++ b/app/app/settings.py
@@ -49,7 +49,7 @@ INSTALLED_APPS = [
     'server.apps.ServerConfig',
     'widget_tweaks',
     'rest_framework',
-    'django_filters'
+    'django_filters',
 ]
 
 MIDDLEWARE = [

--- a/app/app/settings.py
+++ b/app/app/settings.py
@@ -50,6 +50,7 @@ INSTALLED_APPS = [
     'widget_tweaks',
     'rest_framework',
     'django_filters',
+    'social_django',
 ]
 
 MIDDLEWARE = [
@@ -60,6 +61,7 @@ MIDDLEWARE = [
     'django.contrib.auth.middleware.AuthenticationMiddleware',
     'django.contrib.messages.middleware.MessageMiddleware',
     'django.middleware.clickjacking.XFrameOptionsMiddleware',
+    'social_django.middleware.SocialAuthExceptionMiddleware',
 ]
 
 ROOT_URLCONF = 'app.urls'
@@ -75,6 +77,8 @@ TEMPLATES = [
                 'django.template.context_processors.request',
                 'django.contrib.auth.context_processors.auth',
                 'django.contrib.messages.context_processors.messages',
+                'social_django.context_processors.backends',
+                'social_django.context_processors.login_redirect',
             ],
         },
     },
@@ -86,6 +90,13 @@ STATICFILES_DIRS = [
 
 WSGI_APPLICATION = 'app.wsgi.application'
 
+AUTHENTICATION_BACKENDS = [
+    'social_core.backends.github.GithubOAuth2',
+    'django.contrib.auth.backends.ModelBackend',
+]
+
+SOCIAL_AUTH_GITHUB_KEY = os.getenv('OAUTH_GITHUB_KEY')
+SOCIAL_AUTH_GITHUB_SECRET = os.getenv('OAUTH_GITHUB_SECRET')
 
 # Database
 # https://docs.djangoproject.com/en/2.0/ref/settings/#databases

--- a/app/app/settings.py
+++ b/app/app/settings.py
@@ -92,11 +92,16 @@ WSGI_APPLICATION = 'app.wsgi.application'
 
 AUTHENTICATION_BACKENDS = [
     'social_core.backends.github.GithubOAuth2',
+    'social_core.backends.azuread_tenant.AzureADTenantOAuth2',
     'django.contrib.auth.backends.ModelBackend',
 ]
 
 SOCIAL_AUTH_GITHUB_KEY = os.getenv('OAUTH_GITHUB_KEY')
 SOCIAL_AUTH_GITHUB_SECRET = os.getenv('OAUTH_GITHUB_SECRET')
+
+SOCIAL_AUTH_AZUREAD_TENANT_OAUTH2_KEY = os.getenv('OAUTH_AAD_KEY')
+SOCIAL_AUTH_AZUREAD_TENANT_OAUTH2_SECRET = os.getenv('OAUTH_AAD_SECRET')
+SOCIAL_AUTH_AZUREAD_TENANT_OAUTH2_TENANT_ID = os.getenv('OAUTH_AAD_TENANT')
 
 # Database
 # https://docs.djangoproject.com/en/2.0/ref/settings/#databases

--- a/app/app/urls.py
+++ b/app/app/urls.py
@@ -15,15 +15,16 @@ Including another URLconf
 """
 from django.contrib import admin
 from django.urls import path, include
-from django.contrib.auth.views import LoginView, PasswordResetView, LogoutView
+from django.contrib.auth.views import PasswordResetView, LogoutView
+from server.views import LoginView
 from server.urls import router
 
 
 urlpatterns = [
     path('', include('server.urls')),
     path('admin/', admin.site.urls),
-    path('login/', LoginView.as_view(template_name='login.html',
-                                     redirect_authenticated_user=True), name='login'),
+    path('social/', include('social_django.urls')),
+    path('login/', LoginView.as_view(), name='login'),
     path('logout/', LogoutView.as_view(), name='logout'),
     path('password_reset/', PasswordResetView.as_view(), name='password_reset'),
     path('api-auth/', include('rest_framework.urls')),

--- a/app/server/templates/base.html
+++ b/app/server/templates/base.html
@@ -18,8 +18,7 @@
   <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.0.13/css/all.css" integrity="sha384-DNOHZ68U8hZfKXOrtjWvjxusGo9WQnrNx2sqG0tfsghAvtVlRW3tvkXWZh58N9jp"
     crossorigin="anonymous">
   <link href="https://fonts.googleapis.com/css?family=Open+Sans:300,400,700" rel="stylesheet">
-  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/bulma/0.7.1/css/bulma.min.css" crossorigin="anonymous"
-  />
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/bulma/0.7.1/css/bulma.min.css" crossorigin="anonymous">
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bulma-extensions@4.0.1/bulma-divider/dist/css/bulma-divider.min.css" crossorigin="anonymous">
   <link rel="stylesheet" href="{% static 'css/forum.css' %}">
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/Swiper/4.3.3/css/swiper.min.css">

--- a/app/server/templates/base.html
+++ b/app/server/templates/base.html
@@ -20,6 +20,7 @@
   <link href="https://fonts.googleapis.com/css?family=Open+Sans:300,400,700" rel="stylesheet">
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/bulma/0.7.1/css/bulma.min.css" crossorigin="anonymous"
   />
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bulma-extensions@4.0.1/bulma-divider/dist/css/bulma-divider.min.css" crossorigin="anonymous">
   <link rel="stylesheet" href="{% static 'css/forum.css' %}">
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/Swiper/4.3.3/css/swiper.min.css">
   <!-- favicon settings -->

--- a/app/server/templates/login.html
+++ b/app/server/templates/login.html
@@ -49,6 +49,15 @@
           <input class="button is-block is-primary is-middle is-fullwidth" type="submit" value="Login" />
           <input type="hidden" name="next" value="{{ next }}" />
         </form>
+        {% if social_login_enabled %}
+        <div class="is-divider" data-content="OR"></div>
+        {% endif %}
+        {% if github_login %}
+        <a href="{% url 'social:begin' 'github' %}" class="button is-fullwidth is-middle">
+          <span class="icon"><i class="fab fa-github"></i></span>
+          <span>Login with Github</span>
+        </a>
+        {% endif %}
       </div>
     </div>
   </div>

--- a/app/server/templates/login.html
+++ b/app/server/templates/login.html
@@ -53,9 +53,15 @@
         <div class="is-divider" data-content="OR"></div>
         {% endif %}
         {% if github_login %}
-        <a href="{% url 'social:begin' 'github' %}" class="button is-fullwidth is-middle">
+        <a href="{% url 'social:begin' 'github' %}" class="button is-fullwidth mb10">
           <span class="icon"><i class="fab fa-github"></i></span>
           <span>Login with Github</span>
+        </a>
+        {% endif %}
+        {% if aad_login %}
+        <a href="{% url 'social:begin' 'azuread-tenant-oauth2' %}" class="button is-fullwidth mb10">
+          <span class="icon"><i class="fab fa-microsoft"></i></span>
+          <span>Login with Active Directory</span>
         </a>
         {% endif %}
       </div>

--- a/app/server/views.py
+++ b/app/server/views.py
@@ -185,6 +185,7 @@ class LoginView(BaseLoginView):
     redirect_authenticated_user = True
     extra_context = {
         'github_login': bool(settings.SOCIAL_AUTH_GITHUB_KEY),
+        'aad_login': bool(settings.SOCIAL_AUTH_AZUREAD_TENANT_OAUTH2_TENANT_ID),
     }
 
     def get_context_data(self, **kwargs):

--- a/app/server/views.py
+++ b/app/server/views.py
@@ -4,6 +4,7 @@ from io import TextIOWrapper
 import itertools as it
 import logging
 
+from django.contrib.auth.views import LoginView as BaseLoginView
 from django.urls import reverse
 from django.http import HttpResponse, HttpResponseRedirect
 from django.shortcuts import get_object_or_404
@@ -177,6 +178,20 @@ class DataDownloadFile(SuperUserMixin, LoginRequiredMixin, View):
             dump = json.dumps(d.to_json(), ensure_ascii=False)
             response.write(dump + '\n') # write each json object end with a newline
         return response
+
+
+class LoginView(BaseLoginView):
+    template_name = 'login.html'
+    redirect_authenticated_user = True
+    extra_context = {
+        'github_login': bool(settings.SOCIAL_AUTH_GITHUB_KEY),
+    }
+
+    def get_context_data(self, **kwargs):
+        context = super(LoginView, self).get_context_data(**kwargs)
+        context['social_login_enabled'] = any(value for key, value in context.items()
+                                              if key.endswith('_login'))
+        return context
 
 
 class DemoTextClassification(TemplateView):

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,6 +12,8 @@ psycopg2==2.7.5
 python-dateutil==2.7.3
 pytz==2018.4
 six==1.11.0
+social-auth-app-django==3.1.0
+social-auth-core==3.0.0
 text-unidecode==1.2
 tornado==5.0.2
 whitenoise==3.3.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,7 +13,7 @@ python-dateutil==2.7.3
 pytz==2018.4
 six==1.11.0
 social-auth-app-django==3.1.0
-social-auth-core==3.0.0
+social-auth-core[azuread]==3.0.0
 text-unidecode==1.2
 tornado==5.0.2
 whitenoise==3.3.1


### PR DESCRIPTION
Currently the workflow for adding new users to a doccano instance requires an administrator to create accounts using the Django admin tool. This puts a burden on the admin. It also puts a burden on the user since they must maintain a dedicated account and password to access this application. See also the discussion on [card-16405801](https://github.com/chakki-works/doccano/projects/2#card-16405801) around user management.

To make it easier for annotators to do work on doccano, I suggest to add social authentication to the application. This means that a user can sign up with the social provider and get invited to work on annotation projects using that social identity.

As a first step, this pull request implements Github and Azure Active Directory authentication but other social identities should be easily added in the future. This pull request does not solve the problem of having an easy creation of admin users who can create new projects, but at least it makes it simple for annotators to join and work on a project.

Screenshot of the updated login page:

[![Login page screenshot](https://user-images.githubusercontent.com/1086421/51774269-b17b4900-20bf-11e9-96d1-09625ffd19e4.png)](https://user-images.githubusercontent.com/1086421/51774269-b17b4900-20bf-11e9-96d1-09625ffd19e4.png)
