### PR TITLE
Feature/Add continuous delivery of images to DockerHub

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,15 @@
 language: python
+services:
+  - docker
 python:
   - "3.6"
 install:
   - pip install -r requirements.txt
 script:
   - tools/ci.sh
+deploy:
+  - provider: script
+    script: tools/cd.sh
+    on:
+      repo: chakki-works/doccano
+      tags: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,17 @@
 language: python
+
 services:
   - docker
+
 python:
   - "3.6"
+
 install:
   - pip install -r requirements.txt
+
 script:
   - tools/ci.sh
+
 deploy:
   - provider: script
     script: tools/cd.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,8 @@ services:
 python:
   - "3.6"
 
+cache: pip
+
 install:
   - pip install -r requirements.txt
 

--- a/tools/cd.sh
+++ b/tools/cd.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+
+if [[ -z "${DOCKER_USERNAME}" ]]; then echo "Missing DOCKER_USERNAME environment variable" >&2; exit 1; fi
+if [[ -z "${DOCKER_PASSWORD}" ]]; then echo "Missing DOCKER_PASSWORD environment variable" >&2; exit 1; fi
+if [[ -z "${TRAVIS_TAG}" ]]; then echo "Missing TRAVIS_TAG environment variable" >&2; exit 1; fi
+
+set -o errexit
+
+docker build -t "${DOCKER_USERNAME}/doccano:latest" .
+docker build -t "${DOCKER_USERNAME}/doccano:${TRAVIS_TAG}" .
+
+echo "${DOCKER_PASSWORD}" | docker login --username "${DOCKER_USERNAME}" --password-stdin
+
+docker push "${DOCKER_USERNAME}/doccano:latest"
+docker push "${DOCKER_USERNAME}/doccano:${TRAVIS_TAG}"


### PR DESCRIPTION
This change adds continuous delivery of the doccano Docker image to DockerHub. Whenever a tag is created in the repository (e.g. via authoring a release on Github), Travis will build the project and push the image to Docker. The `latest` Docker tag will be updated to the current release and a new Docker tag will be created which is named the same as the git tag.

Example successful release build: [logs](https://travis-ci.org/CatalystCode/doccano/builds/485408772), [images](https://cloud.docker.com/repository/registry-1.docker.io/cwolff/doccano/tags).

Open questions:
- Do you have a Docker account which you'd like to use for the images?
  - If yes: could you please add `DOCKER_USERNAME` and `DOCKER_PASSWORD` in the Travis settings page for doccano ([documentation](https://docs.travis-ci.com/user/environment-variables/#defining-variables-in-repository-settings))?
  - If no: let me know and I can configure the continuous delivery via one of my accounts.