### PR TITLE
revise the offset calculation for sequence labeling

### DIFF
--- a/app/server/models.py
+++ b/app/server/models.py
@@ -154,7 +154,7 @@ class Document(models.Model):
                 start_mapping[cursor] = ind
                 cursor += len(text[ind].encode('utf-16-le')) // 2
                 end_mapping[cursor] = ind
-            for a in annotations
+            for a in annotations:
                 assert(a.start_offset in start_mapping)
                 a.start_offset = start_mapping[a.start_offset]
                 assert(a.end_offset in end_mapping)

--- a/app/server/models.py
+++ b/app/server/models.py
@@ -148,7 +148,18 @@ class Document(models.Model):
         if self.project.is_type_of(Project.DOCUMENT_CLASSIFICATION):
             return self.doc_annotations.all()
         elif self.project.is_type_of(Project.SEQUENCE_LABELING):
-            return self.seq_annotations.all()
+            annotations = self.seq_annotations.all()
+            start_mapping, end_mapping, cursor = dict(), dict(), 0
+            for ind in range(len(self.text)):
+                start_mapping[cursor] = ind
+                cursor += len(text[ind].encode('utf-16-le')) // 2
+                end_mapping[cursor] = ind
+            for a in annotations
+                assert(a.start_offset in start_mapping)
+                a.start_offset = start_mapping[a.start_offset]
+                assert(a.end_offset in end_mapping)
+                a.end_offset = end_mapping[a.end_offset]
+            return annotations
         elif self.project.is_type_of(Project.Seq2seq):
             return self.seq2seq_annotations.all()
 

--- a/app/server/models.py
+++ b/app/server/models.py
@@ -149,16 +149,16 @@ class Document(models.Model):
             return self.doc_annotations.all()
         elif self.project.is_type_of(Project.SEQUENCE_LABELING):
             annotations = self.seq_annotations.all()
-            start_mapping, end_mapping, cursor = dict(), dict(), 0
+            index_mapping, cursor = dict(), 0
             for ind in range(len(self.text)):
-                start_mapping[cursor] = ind
+                index_mapping[cursor] = ind
                 cursor += len(text[ind].encode('utf-16-le')) // 2
-                end_mapping[cursor] = ind
+            index_mapping[cursor] = len(self.text)
             for a in annotations:
-                assert(a.start_offset in start_mapping)
-                a.start_offset = start_mapping[a.start_offset]
-                assert(a.end_offset in end_mapping)
-                a.end_offset = end_mapping[a.end_offset]
+                assert(a.start_offset in index_mapping)
+                a.start_offset = index_mapping[a.start_offset]
+                assert(a.end_offset in index_mapping)
+                a.end_offset = index_mapping[a.end_offset]
             return annotations
         elif self.project.is_type_of(Project.Seq2seq):
             return self.seq2seq_annotations.all()


### PR DESCRIPTION
The current implementations relies on the js script (`https://github.com/chakki-works/doccano/blob/master/app/server/static/js/sequence_labeling.js` line44-45, line51-52) to calculate the start & end offset for annotated entities. Due to the behavior of the `length` function in javascript, these offsets are based on the number of utf-16 units (e.g., some emoji would have a length of 2). This PR fixes this issue by revising the annotation offsets. 

PS: Thanks for releasing the project :- ), love it