### PR TITLE
Fix psycopg2 warning by updating to psycopg2-binary

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -10,7 +10,7 @@ Faker==0.8.8
 flake8==3.6.0
 gunicorn==19.9.0
 mixer==6.1.3
-psycopg2==2.7.5
+psycopg2-binary==2.7.7
 python-dateutil==2.7.3
 pytz==2018.4
 six==1.11.0


### PR DESCRIPTION
## Description

As of the title, it was fixed warning of psycopg2.
According to the message that psycopg 2 is renamed to psycopg 2 - binary as the version is upgraded.


### Wanring log

```
$ docker exec doccano tools/create-admin.sh "admin" "admin@example.com" "password"
/usr/local/lib/python3.6/site-packages/psycopg2/__init__.py:144: UserWarning: The psycopg2 wheel package will be renamed from release 2.8; in order to keep installing from binary
 please use "pip install psycopg2-binary" instead. For details see: <http://initd.org/psycopg/docs/install.html#binary-install-from-pypi>.
  """)
/usr/local/lib/python3.6/site-packages/psycopg2/__init__.py:144: UserWarning: The psycopg2 wheel package will be renamed from release 2.8; in order to keep installing from binary
 please use "pip install psycopg2-binary" instead. For details see: <http://initd.org/psycopg/docs/install.html#binary-install-from-pypi>.
  """)
Operations to perform:
  Apply all migrations: admin, auth, contenttypes, server, sessions, social_django
Running migrations:
  No migrations to apply.
Superuser created successfully.
/usr/local/lib/python3.6/site-packages/psycopg2/__init__.py:144: UserWarning: The psycopg2 wheel package will be renamed from release 2.8; in order to keep installing from binary
 please use "pip install psycopg2-binary" instead. For details see: <http://initd.org/psycopg/docs/install.html#binary-install-from-pypi>.
  """)
```

### Normal(fixed) log

```
$ docker exec doccano tools/create-admin.sh "admin" "admin@example.com" "password"
Operations to perform:
  Apply all migrations: admin, auth, contenttypes, server, sessions, social_django
Running migrations:
  No migrations to apply.
Superuser created successfully.
```