### PR TITLE
Implement Heroku Button

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,0 +1,1 @@
+web: gunicorn --pythonpath app app.wsgi

--- a/README.md
+++ b/README.md
@@ -37,7 +37,11 @@ Doccano can be deployed to Azure ([Web App for Containers](https://azure.microso
 
 ### Heroku
 
-Doccano can be deployed to [Heroku](https://www.heroku.com/) by following these steps:
+Doccano can be deployed to [Heroku](https://www.heroku.com/) by clicking on the button below:
+
+[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://heroku.com/deploy)
+
+Of course, you can deploy doccano by using [heroku-cli](https://devcenter.heroku.com/articles/heroku-cli).
 
 ```bash
 heroku create

--- a/app.json
+++ b/app.json
@@ -24,6 +24,11 @@
             "description": "Google Analytics tracking id.",
             "required": false,
             "value": ""
+        },
+        "DEBUG": {
+            "description": "Debug mode or not.",
+            "required": false,
+            "value": "False"
         }
     },
     "scripts": {

--- a/app.json
+++ b/app.json
@@ -1,0 +1,45 @@
+{
+    "name": "doccano",
+    "description": "Open source text annotation tool for machine learning practitioner.",
+    "keywords": ["Python", "Machine Learning", "Annotation"],
+    "website": "https://doccano.herokuapp.com/",
+    "repository": "https://github.com/chakki-works/doccano",
+    "logo": "https://github.com/chakki-works/doccano/wiki/images/doccano.png",
+    "success_url": "/",
+    "env": {
+        "ADMIN_USER_NAME": {
+            "description": "The user name for the admin account."
+        },
+        "ADMIN_CONTACT_EMAIL": {
+            "description": "The contact email address for the admin account."
+        },
+        "ADMIN_PASSWORD": {
+            "description": "The password for the admin account."
+        },
+        "SECRET_KEY": {
+            "description": "The value to use as the Django secret key.",
+            "generator": "secret"
+        },
+        "GOOGLE_TRACKING_ID": {
+            "description": "Google Analytics tracking id.",
+            "required": false,
+            "value": ""
+        }
+    },
+    "scripts": {
+        "postdeploy": "sh tools/heroku.sh deploy"
+    },
+    "addons": [
+        {
+            "plan": "heroku-postgresql:hobby-dev"
+        }
+    ],
+    "buildpacks": [
+        {
+            "url": "heroku/nodejs"
+        },
+        {
+            "url": "heroku/python"
+        }
+    ]
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,8 @@
+{
+    "engines": {
+        "node": "8.x"
+    },
+    "scripts": {
+        "heroku-postbuild": "sh tools/heroku.sh build"
+    }
+}

--- a/tools/heroku.sh
+++ b/tools/heroku.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+
+set -o errexit
+
+if [ "$1" = "build" ]; then
+    cd app/server
+    npm install --only=prod
+    npm install --only=dev
+    ./node_modules/.bin/webpack --config ./webpack.config.js --mode production
+    echo "Done webpack build."
+    ls ./static/bundle
+else
+    python app/manage.py migrate
+    python app/manage.py collectstatic --noinput
+    python app/manage.py create_admin --noinput --username="$ADMIN_USER_NAME" --email="$ADMIN_CONTACT_EMAIL" --password="$ADMIN_PASSWORD"
+
+fi


### PR DESCRIPTION
This pull request implements [Heroku Button](https://devcenter.heroku.com/articles/heroku-button) to enable one-click deployment on the Heroku.

* Heroku Button on the `README.md` is enabled after the merge. Because Heroku Button refers `master` branch by default.
* The following button is specified to use my branch ([`icoxfog417/doccano/tree/heroku_button`](https://github.com/icoxfog417/doccano/tree/heroku_button)). You can use it to test/confirm the behavior.

[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://heroku.com/deploy?template=https://github.com/icoxfog417/doccano/tree/heroku_button)

I already confirm the demo app & annotation on the created project works fine.
