### PR TITLE
Correct emoji length calculation

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,13 +52,14 @@ git push heroku master
 ## Features
 
 * Collaborative annotation
-* Language independent
+* Multi-Language support
+* Emoji :smile: support
 * (future) Auto labeling
 
 ## Requirements
 
 * Python 3.6+
-* django 2.0.5+
+* Django 2.1.7+
 * Google Chrome(highly recommended)
 
 ## Installation

--- a/app/server/static/js/sequence_labeling.js
+++ b/app/server/static/js/sequence_labeling.js
@@ -16,7 +16,7 @@ Vue.component('annotator', {
                          v-if="id2label[r.label]"\
                          v-bind:class="{tag: id2label[r.label].text_color}"\
                          v-bind:style="{ color: id2label[r.label].text_color, backgroundColor: id2label[r.label].background_color }"\
-                    >{{ text.slice(r.start_offset, r.end_offset) }}<button class="delete is-small"\
+                    >{{ [...text].slice(r.start_offset, r.end_offset).join(\'\') }}<button class="delete is-small"\
                                          v-if="id2label[r.label].text_color"\
                                          @click="removeLabel(r)"></button></span>\
                </div>',
@@ -41,15 +41,15 @@ Vue.component('annotator', {
         const preSelectionRange = range.cloneRange();
         preSelectionRange.selectNodeContents(this.$el);
         preSelectionRange.setEnd(range.startContainer, range.startOffset);
-        start = preSelectionRange.toString().length;
-        end = start + range.toString().length;
+        start = [...preSelectionRange.toString()].length;
+        end = start + [...range.toString()].length;
       } else if (document.selection && document.selection.type !== 'Control') {
         const selectedTextRange = document.selection.createRange();
         const preSelectionTextRange = document.body.createTextRange();
         preSelectionTextRange.moveToElementText(this.$el);
         preSelectionTextRange.setEndPoint('EndToStart', selectedTextRange);
-        start = preSelectionTextRange.text.length;
-        end = start + selectedTextRange.text.length;
+        start = [...preSelectionTextRange.text].length;
+        end = start + [...selectedTextRange.text].length;
       }
       this.startOffset = start;
       this.endOffset = end;


### PR DESCRIPTION
# Description

This PR makes doccano support for emoji annotation. The problem is described in #99.
Due to the encoding used by javascript, the emoji length is different between python and javascript.

# Demo

## input data
```
{"text": "label1 😄 label2, label3"}
{"text": "label1 🎊 label2, label3"}
{"text": "label1 👩‍❤️‍👩 label2, label3"}
```
## Annotation

![image](https://user-images.githubusercontent.com/10768193/53863818-6f361780-402e-11e9-89ac-499d99a2a56d.png)

![image](https://user-images.githubusercontent.com/10768193/53863847-7f4df700-402e-11e9-9948-6962e8271fdc.png)


## Output data

**before**
emoji_export.json
```
{"doc_id": 3, "text": "label1 😄 label2, label3", "entities": [[7, 9, "l1"], [10, 16, "l2"]], "username": "admin", "metadata": {}}
{"doc_id": 4, "text": "label1 🎊 label2, label3", "entities": [[7, 9, "l1"], [10, 16, "l2"]], "username": "admin", "metadata": {}}
{"doc_id": 5, "text": "label1 👩‍❤️‍👩 label2, label3", "entities": [[7, 15, "l1"], [16, 22, "l2"]], "username": "admin", "metadata": {}}
```

**after**
emoji_export.json
```
{"doc_id": 42, "text": "label1 😄 label2, label3", "entities": [[7, 8, "l1"], [9, 15, "l2"]], "username": "admin", "metadata": {}}
{"doc_id": 43, "text": "label1 🎊 label2, label3", "entities": [[7, 8, "l1"], [9, 15, "l2"]], "username": "admin", "metadata": {}}
{"doc_id": 44, "text": "label1 👩‍❤️‍👩 label2, label3", "entities": [[7, 13, "l1"], [14, 20, "l2"]], "username": "admin", "metadata": {}}
```

# Some test cases

length in python 
```
print(len('😄')) # 1
print(len('👩‍❤️‍👩')) # 6
```

length in javascript
```
console.log('😄'.length); // 2
console.log('😄'.normalize('NFC').length); // 2
console.log([...'😄'].length); // 1

console.log('👩‍❤️‍👩'.length); // 8
console.log('👩‍❤️‍👩'.normalize('NFC').length); // 8
console.log([...'👩‍❤️‍👩'].length); // 6

console.log("label1 label2, label3".length); // 21
console.log([..."label1 label2, label3"].length); // 21
console.log("label1 😄 label2, label3".length); // 24
console.log([..."label1 😄 label2, label3"].length); // 23

console.log("label1 😄 label2, label3".slice(7,9)); // 😄
```

# Which to use, `spread operator` or `Array.from()`

- The **Array.from()** method creates a new, shallow-copied `Array` instance from an array-like or iterable object.
- **Spread syntax** allows an iterable such as an array expression or string to be expanded in places where zero or more arguments (for function calls) or elements (for array literals) are expected, or an object expression to be expanded in places where zero or more key-value pairs (for object literals) are expected.

Because `spread` works in place, this will save more memory space than `Array.from()`, so it is better to use `spread operator`.

# TODO
- [X] Test for all Unicode symbols

Confirm the Unicode length is the same between Python and Javascript

- **For plane 0 (BMP)**：This shows doccano support for most of the language with the correct length
  -  [**unicode_length.py**](https://gist.github.com/BrambleXu/e5df6df6a6102d0b4145a5962190f305): output all unicode in BMP and its length calculated by Python
  - [**unicode_plane.txt**](https://gist.github.com/BrambleXu/744559eea3b27df0b813e1c4396a6078): the result 
  -  [**unicode_length.js**](https://gist.github.com/BrambleXu/268ce0c57154db17b3efc7422323028e): compare the length calculated by Javascript

- **For emoji**: This shows doccano support for all emoji with the correct length
  - [**emoji_length.py**](https://gist.github.com/BrambleXu/1bd36eb92e06ba6fa893aac39d525191)：output all unicode in emoji and its length calculated by Python
  - [**emoji_length.txt**](https://gist.github.com/BrambleXu/774315da29ffdc43721f353b3570f092)： the result 
  - [**emoji_length.js**](https://gist.github.com/BrambleXu/3b15a6869d2c2db98be00a4a6b04b837#file-emoji_length-js)：compare the length calculated by Javascript

All these tests show doccano is no problem for Unicode length calculation. 

# Reference
[Unicode in JavaScript](https://flaviocopes.com/javascript-unicode/#emojis)

