### PR TITLE
add nodejs requirement to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ git push heroku master
 
 * Python 3.6+
 * Django 2.1.7+
+* Node.js 8.0+
 * Google Chrome(highly recommended)
 
 ## Installation


### PR DESCRIPTION
Recently when building Doccano, I had to change a few configurations in order to setup `npm` and `node.js` properly.  Given the following lines of the installation instructions...

```bash
cd server
npm install
npm run build
cd ..
```

...adding `Node.js 8.0+` as a requirement made sense to me.