### PR TITLE
Enhancement/Turn dockerfile into a multi-stage build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 ARG PYTHON_VERSION="3.6"
-FROM python:${PYTHON_VERSION}
+FROM python:${PYTHON_VERSION} AS builder
 
 ARG NODE_VERSION="8.x"
 RUN curl -sL "https://deb.nodesource.com/setup_${NODE_VERSION}" | bash - \
@@ -7,18 +7,27 @@ RUN curl -sL "https://deb.nodesource.com/setup_${NODE_VERSION}" | bash - \
  && rm -rf /var/lib/apt/lists/*
 
 COPY app/server/package*.json /doccano/app/server/
-RUN cd /doccano/app/server && npm ci
+RUN cd /doccano/app/server \
+ && npm ci
 
 COPY requirements.txt /
-RUN pip install --no-cache-dir -r /requirements.txt
+RUN pip install -r /requirements.txt \
+ && pip wheel -r /requirements.txt -w /deps
 
 COPY app/server/static /doccano/app/server/static/
 COPY app/server/webpack.config.js /doccano/app/server/
-RUN cd /doccano/app/server && DEBUG=False npm run build
+RUN cd /doccano/app/server \
+ && DEBUG=False npm run build \
+ && rm -rf node_modules/
 
 COPY . /doccano
 
-WORKDIR /doccano
+FROM python:${PYTHON_VERSION}-slim AS runtime
+
+COPY --from=builder /deps /deps
+RUN pip install --no-cache-dir /deps/*.whl
+
+COPY --from=builder /doccano /doccano
 
 ENV DEBUG="True"
 ENV SECRET_KEY="change-me-in-production"
@@ -27,6 +36,7 @@ ENV WORKERS="2"
 ENV GOOGLE_TRACKING_ID=""
 ENV AZURE_APPINSIGHTS_IKEY=""
 
+WORKDIR /doccano
 EXPOSE ${PORT}
 
 CMD ["/doccano/tools/run.sh"]


### PR DESCRIPTION
Using a multi-stage build reduces the image size from 1.23GB to 331MB which means that any node running doccano can now start-up faster.

Additionally, the multi-stage build means that we no longer include in the production image development tools like node (now excluded since it's only installed in the builder layer) or gcc (now excluded since the production layer is based on python-slim) which reduces the attack surface of the image.