### PR TITLE
Fix issue with text import yielding internal server error

### DIFF
--- a/app/server/utils.py
+++ b/app/server/utils.py
@@ -344,7 +344,7 @@ class PlainTextParser(FileParser):
         while True:
             batch = list(itertools.islice(file, IMPORT_BATCH_SIZE))
             if not batch:
-                raise StopIteration
+                break
             yield [{'text': line.strip()} for line in batch]
 
 


### PR DESCRIPTION
Fix for 
```
Internal Server Error: /v1/projects/2/docs/upload
Traceback (most recent call last):
  File "/doccano/app/server/utils.py", line 347, in parse
    raise StopIteration
StopIteration

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/doccano/venv/lib/python3.7/site-packages/django/core/handlers/exception.py", line 34, in inner
    response = get_response(request)
  File "/doccano/venv/lib/python3.7/site-packages/django/core/handlers/base.py", line 126, in _get_response
    response = self.process_exception_by_middleware(e, request)
  File "/doccano/venv/lib/python3.7/site-packages/django/core/handlers/base.py", line 124, in _get_response
    response = wrapped_callback(request, *callback_args, **callback_kwargs)
  File "/doccano/venv/lib/python3.7/site-packages/django/views/decorators/csrf.py", line 54, in wrapped_view
    return view_func(*args, **kwargs)
  File "/doccano/venv/lib/python3.7/site-packages/django/views/generic/base.py", line 68, in view
    return self.dispatch(request, *args, **kwargs)
  File "/doccano/venv/lib/python3.7/site-packages/rest_framework/views.py", line 483, in dispatch
    response = self.handle_exception(exc)
  File "/doccano/venv/lib/python3.7/site-packages/rest_framework/views.py", line 443, in handle_exception
    self.raise_uncaught_exception(exc)
  File "/doccano/venv/lib/python3.7/site-packages/rest_framework/views.py", line 480, in dispatch
    response = handler(request, *args, **kwargs)
  File "/doccano/app/server/api.py", line 179, in post
    storage.save(self.request.user)
  File "/usr/local/Cellar/python/3.7.2_1/Frameworks/Python.framework/Versions/3.7/lib/python3.7/contextlib.py", line 74, in inner
    return func(*args, **kwds)
  File "/doccano/app/server/utils.py", line 118, in save
    for data in self.data:
RuntimeError: generator raised StopIteration
```
when importing text data