### PR TITLE
[WIP] Smaller screen menu is not accessible

### DIFF
--- a/app/server/templates/base.html
+++ b/app/server/templates/base.html
@@ -46,6 +46,11 @@
         <a class="navbar-item" href="{% url 'index' %}">
           <img src="{% static 'images/logo.png' %}" width="32" height="32">
           <b>doccano</b>
+          <a role="button" class="navbar-burger burger" aria-label="menu" aria-expanded="false" data-target="topNav">
+            <span aria-hidden="true"></span>
+            <span aria-hidden="true"></span>
+            <span aria-hidden="true"></span>
+          </a>
         </a>
         {% block navigation %}{% endblock %}
       </div>
@@ -108,6 +113,9 @@
         prevEl: '.swiper-button-prev',
       },
     })
+
+    document.querySelector('.navbar-burger').addEventListener('click', () =>
+      document.getElementById('topNav').classList.toggle('is-active'))
   </script>
 </body>
 </html>


### PR DESCRIPTION
By default Bulma would hide navbars on smaller screens.
There's also element for providing 'burger' (`Ξ` menu icon), but it needs additional js to toggle proper class on navbar (`.is-active`)
This is WIP, just to bring up this issue.
With current changes it will look like this:
![image](https://user-images.githubusercontent.com/1506905/55035000-8493d580-501f-11e9-8800-f25ea2ac61fd.png)
Issue is bg color on .navbar-menu
![image](https://user-images.githubusercontent.com/1506905/55034990-7ba30400-501f-11e9-973b-663effcc3964.png)
Without bg color it's like this 
![image](https://user-images.githubusercontent.com/1506905/55035152-d2104280-501f-11e9-9b7d-9cd801edcb44.png)

Needs: 
- solutions on whether should: 1) have menu opened by default (just adding `is-active`), 2) have it toggled on burger click (didn't know how to best organize js - it's only one click handler, yet it's in top level template, which poses a question whether this should be vue or just plain js)
- solution on appearances on smaller screen: font inconsistencies (which are more eye catching when all items are side by side) and bg color on items