### PR TITLE
Bugfix/Fix NoReverseMatch on demo page for superuser

### DIFF
--- a/app/server/templates/annotation/annotation_base.html
+++ b/app/server/templates/annotation/annotation_base.html
@@ -4,7 +4,7 @@
 <link rel="stylesheet" href="{% static 'css/annotation.css' %}">
 {% endblock %}
 {% block navigation %}
-{% if user.is_superuser %}
+{% if user.is_superuser and 'project_id' in view.kwargs %}
 <a class="navbar-item" href="{% url 'dataset' view.kwargs.project_id %}">
   <span class="icon">
     <i class="fas fa-edit"></i>


### PR DESCRIPTION
Currently if a superuser accesses any of the demo pages, the Django server crashes with a NoReverseMatch as shown in the screenshot below:

![Screenshot showing NoReverseMatch crash](https://user-images.githubusercontent.com/1086421/56097854-a5857300-5ec7-11e9-9782-a0274d01a1ac.png)

This is caused by the fact that the demo pages re-use the annotation base template. When the user is a superuser, the annotation base template includes a link to edit the current project id. However, demo
projects don't have an id which causes the crash. This change fixes the crash by only including the project edit link if the Django context contains a project id.