### PR TITLE
Enhancement/Enable non-SSL connections to the database

### DIFF
--- a/app/app/settings.py
+++ b/app/app/settings.py
@@ -15,6 +15,7 @@ from os import path
 import django_heroku
 import dj_database_url
 from environs import Env
+from furl import furl
 
 
 # Build paths inside the project like this: path.join(BASE_DIR, ...)
@@ -195,7 +196,11 @@ LOGIN_REDIRECT_URL = '/projects/'
 LOGOUT_REDIRECT_URL = '/'
 
 # Change 'default' database configuration with $DATABASE_URL.
-DATABASES['default'].update(dj_database_url.config(conn_max_age=500, ssl_require=True))
+DATABASES['default'].update(dj_database_url.config(
+    env='DATABASE_URL',
+    conn_max_age=500,
+    ssl_require='sslmode' not in furl(env('DATABASE_URL', '')).args,
+))
 
 # Honor the 'X-Forwarded-Proto' header for request.is_secure()
 SECURE_PROXY_SSL_HEADER = ('HTTP_X_FORWARDED_PROTO', 'https')

--- a/app/app/settings.py
+++ b/app/app/settings.py
@@ -198,7 +198,7 @@ LOGOUT_REDIRECT_URL = '/'
 # Change 'default' database configuration with $DATABASE_URL.
 DATABASES['default'].update(dj_database_url.config(
     env='DATABASE_URL',
-    conn_max_age=500,
+    conn_max_age=env.int('DATABASE_CONN_MAX_AGE', 500),
     ssl_require='sslmode' not in furl(env('DATABASE_URL', '')).args,
 ))
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,6 +14,7 @@ environs==4.1.0
 djangorestframework-xml==1.4.0
 Faker==0.8.8
 flake8==3.6.0
+furl==2.0.0
 gunicorn==19.9.0
 mixer==6.1.3
 model-mommy==1.6.0


### PR DESCRIPTION
Currently, whenever the database is changed from the default SQLite via the DATABASE_URL environment variable, the connection to the database is forced to be SSL. This is a great default for production use-cases. However, in some scenarios, users may not want to use SSL, e.g. when testing against a local MySQL or PostgreSQL database.

This change enables users to explicitly request a non-SSL connection to the database by passing the `?sslmode=disable` (or similar) query argument in the DATABASE_URL environment variable.

For backwards compatibility, if the `sslmode` is not set explicitly in the connection URL, the code still defaults to requiring SSL on the connection.