### PR TITLE
Enhancement/Remove empty lines from upload

### DIFF
--- a/app/server/tests/data/example.empty.jsonl
+++ b/app/server/tests/data/example.empty.jsonl
@@ -1,0 +1,5 @@
+{"text": "example"}
+
+{"text": "example"}
+
+{"text": "example"}

--- a/app/server/tests/data/example.empty.txt
+++ b/app/server/tests/data/example.empty.txt
@@ -1,0 +1,5 @@
+example1
+
+example2
+
+example3

--- a/app/server/tests/test_api.py
+++ b/app/server/tests/test_api.py
@@ -766,6 +766,12 @@ class TestUploader(APITestCase):
                                 format='json',
                                 expected_status=status.HTTP_201_CREATED)
 
+    def test_can_upload_json_data_with_empty_lines(self):
+        self.upload_test_helper(url=self.classification_url,
+                                filename='example.empty.jsonl',
+                                format='json',
+                                expected_status=status.HTTP_201_CREATED)
+
 
 class TestParser(APITestCase):
 

--- a/app/server/tests/test_api.py
+++ b/app/server/tests/test_api.py
@@ -754,6 +754,12 @@ class TestUploader(APITestCase):
                                 format='plain',
                                 expected_status=status.HTTP_201_CREATED)
 
+    def test_can_upload_plain_text_with_empty_lines(self):
+        self.upload_test_helper(url=self.classification_url,
+                                filename='example.empty.txt',
+                                format='plain',
+                                expected_status=status.HTTP_201_CREATED)
+
     def test_can_upload_data_without_label(self):
         self.upload_test_helper(url=self.classification_url,
                                 filename='example.jsonl',

--- a/app/server/utils.py
+++ b/app/server/utils.py
@@ -387,16 +387,19 @@ class JSONParser(FileParser):
 
     def parse(self, file):
         data = []
+
         for i, line in enumerate(file, start=1):
             if len(data) >= IMPORT_BATCH_SIZE:
                 yield data
                 data = []
+
             try:
                 j = json.loads(line)
                 j['meta'] = json.dumps(j.get('meta', {}))
                 data.append(j)
             except json.decoder.JSONDecodeError:
                 raise FileParseException(line_num=i, line=line)
+
         if data:
             yield data
 

--- a/app/server/utils.py
+++ b/app/server/utils.py
@@ -345,7 +345,8 @@ class PlainTextParser(FileParser):
             batch = list(itertools.islice(file, IMPORT_BATCH_SIZE))
             if not batch:
                 break
-            yield [{'text': line.strip()} for line in batch]
+            lines = [line.strip() for line in batch]
+            yield [{'text': line} for line in lines if line]
 
 
 class CSVParser(FileParser):

--- a/app/server/utils.py
+++ b/app/server/utils.py
@@ -393,6 +393,10 @@ class JSONParser(FileParser):
                 yield data
                 data = []
 
+            line = line.strip()
+            if not line:
+                continue
+
             try:
                 j = json.loads(line)
                 j['meta'] = json.dumps(j.get('meta', {}))


### PR DESCRIPTION
As discussed in https://github.com/chakki-works/doccano/issues/168, having empty lines in the upload data files can cause user confusion since they lead to the entire upload being rejected.

As such, this change filters out empty lines in upload text and json files instead of failing the upload.