### PR TITLE
Enhancement/Publish each master to Docker Hub

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,11 @@ script:
 
 deploy:
   - provider: script
-    script: tools/cd.sh
+    script: tools/cd.sh travis-${TRAVIS_BUILD_NUMBER}
     on:
-      repo: chakki-works/doccano
+      branch: master
+
+  - provider: script
+    script: tools/cd.sh ${TRAVIS_TAG}
+    on:
       tags: true

--- a/tools/cd.sh
+++ b/tools/cd.sh
@@ -2,14 +2,14 @@
 
 if [[ -z "${DOCKER_USERNAME}" ]]; then echo "Missing DOCKER_USERNAME environment variable" >&2; exit 1; fi
 if [[ -z "${DOCKER_PASSWORD}" ]]; then echo "Missing DOCKER_PASSWORD environment variable" >&2; exit 1; fi
-if [[ -z "${TRAVIS_TAG}" ]]; then echo "Missing TRAVIS_TAG environment variable" >&2; exit 1; fi
+if [[ -z "$1" ]]; then echo "Usage: $0 <tag>" >&2; exit 1; fi
 
 set -o errexit
 
 docker build -t "${DOCKER_USERNAME}/doccano:latest" .
-docker build -t "${DOCKER_USERNAME}/doccano:${TRAVIS_TAG}" .
+docker build -t "${DOCKER_USERNAME}/doccano:$1" .
 
 echo "${DOCKER_PASSWORD}" | docker login --username "${DOCKER_USERNAME}" --password-stdin
 
 docker push "${DOCKER_USERNAME}/doccano:latest"
-docker push "${DOCKER_USERNAME}/doccano:${TRAVIS_TAG}"
+docker push "${DOCKER_USERNAME}/doccano:$1"


### PR DESCRIPTION
As discussed in https://github.com/chakki-works/doccano/issues/182, this change publishes a new docker image on each master build which enables users to more quickly get access to new versions of doccano.

The master builds are named like `travis-[0-9]+` to differentiate them clearly from official manual releases via git tags which preserve the exact name of the tag as the docker image name (just like prior to this change). Additionally, the `latest` docker image gets updated on each build.

The screenshot below shows an example of a master docker image and a release docker image published by the new CD script:

![Screenshot showing a master docker image and a tag docker image](https://user-images.githubusercontent.com/1086421/56932405-a87c8800-6ab1-11e9-9959-6ccf750dc566.png)
