### PR TITLE
Change ami for awsdeploy and update the SequenceAnnotation serializer

### DIFF
--- a/app/server/serializers.py
+++ b/app/server/serializers.py
@@ -137,7 +137,7 @@ class SequenceAnnotationSerializer(serializers.ModelSerializer):
 
     class Meta:
         model = SequenceAnnotation
-        fields = ('id', 'prob', 'label', 'start_offset', 'end_offset', 'user', 'document')
+        fields = ('id', 'prob', 'label', 'label_text', 'start_offset', 'end_offset', 'user', 'document')
         read_only_fields = ('user',)
 
     def get_label_text(self, instance):

--- a/app/server/serializers.py
+++ b/app/server/serializers.py
@@ -133,11 +133,15 @@ class SequenceAnnotationSerializer(serializers.ModelSerializer):
     #label = ProjectFilteredPrimaryKeyRelatedField(queryset=Label.objects.all())
     label = serializers.PrimaryKeyRelatedField(queryset=Label.objects.all())
     document = serializers.PrimaryKeyRelatedField(queryset=Document.objects.all())
+    label_text = serializers.SerializerMethodField()
 
     class Meta:
         model = SequenceAnnotation
         fields = ('id', 'prob', 'label', 'start_offset', 'end_offset', 'user', 'document')
         read_only_fields = ('user',)
+
+    def get_label_text(self, instance):
+        return instance.label.text
 
 
 class Seq2seqAnnotationSerializer(serializers.ModelSerializer):

--- a/awsdeploy.yml
+++ b/awsdeploy.yml
@@ -25,11 +25,11 @@ Resources:
     Type: 'AWS::EC2::Instance'
     Properties:
       InstanceType: t2.micro
-      ImageId: ami-0ac019f4fcb7cb7e6
+      ImageId: ami-06397100adf427136
       KeyName: !Ref KeyName
       SecurityGroups:
         - !Ref AppSG
-      UserData: !Base64 
+      UserData: !Base64
         'Fn::Join':
           - ''
           - - |
@@ -162,8 +162,7 @@ Parameters:
     AllowedPattern: '^[a-zA-Z0-9]*$'
 Outputs:
   PublicDNS:
-    Value: !GetAtt 
+    Value: !GetAtt
       - App
       - PublicDnsName
     Description: Newly created server DNS address
-


### PR DESCRIPTION
This PR fixes an issue with a invalid AMI id in awsdeploy.yaml (switched it to an Ubuntu 18.04 AMI) and added a new field to SequenceAnnotationSerializer to have more explicit label data when exporting.