### PR TITLE
Bugfix/Fix sslmode with custom sqlite path and on Heroku

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -33,7 +33,6 @@ RUN pip install --no-cache-dir /deps/*.whl
 
 COPY --from=builder /doccano /doccano
 
-ENV IS_HEROKU="False"
 ENV DEBUG="True"
 ENV SECRET_KEY="change-me-in-production"
 ENV PORT="80"

--- a/Dockerfile
+++ b/Dockerfile
@@ -33,6 +33,7 @@ RUN pip install --no-cache-dir /deps/*.whl
 
 COPY --from=builder /doccano /doccano
 
+ENV IS_HEROKU="False"
 ENV DEBUG="True"
 ENV SECRET_KEY="change-me-in-production"
 ENV PORT="80"

--- a/app/app/settings.py
+++ b/app/app/settings.py
@@ -220,3 +220,7 @@ APPLICATION_INSIGHTS = {
 }
 
 django_heroku.settings(locals(), test_runner=False)
+
+# work-around for dj-database-url: explicitly disable ssl for sqlite
+if DATABASES['default'].get('ENGINE') == 'django.db.backends.sqlite3':
+    DATABASES['default'].get('OPTIONS', {}).pop('sslmode', None)

--- a/app/app/settings.py
+++ b/app/app/settings.py
@@ -219,7 +219,9 @@ APPLICATION_INSIGHTS = {
     'ikey': AZURE_APPINSIGHTS_IKEY if AZURE_APPINSIGHTS_IKEY else None,
 }
 
-django_heroku.settings(locals(), test_runner=False)
+# work-around for django-heroku: don't overwrite sslmode outside of heroku
+if env.bool('IS_HEROKU', True):
+    django_heroku.settings(locals(), test_runner=False)
 
 # work-around for dj-database-url: explicitly disable ssl for sqlite
 if DATABASES['default'].get('ENGINE') == 'django.db.backends.sqlite3':

--- a/app/app/settings.py
+++ b/app/app/settings.py
@@ -195,12 +195,18 @@ LOGIN_URL = '/login/'
 LOGIN_REDIRECT_URL = '/projects/'
 LOGOUT_REDIRECT_URL = '/'
 
+django_heroku.settings(locals(), test_runner=False)
+
 # Change 'default' database configuration with $DATABASE_URL.
 DATABASES['default'].update(dj_database_url.config(
     env='DATABASE_URL',
     conn_max_age=env.int('DATABASE_CONN_MAX_AGE', 500),
     ssl_require='sslmode' not in furl(env('DATABASE_URL', '')).args,
 ))
+
+# work-around for dj-database-url: explicitly disable ssl for sqlite
+if DATABASES['default'].get('ENGINE') == 'django.db.backends.sqlite3':
+    DATABASES['default'].get('OPTIONS', {}).pop('sslmode', None)
 
 # Honor the 'X-Forwarded-Proto' header for request.is_secure()
 SECURE_PROXY_SSL_HEADER = ('HTTP_X_FORWARDED_PROTO', 'https')
@@ -218,11 +224,3 @@ AZURE_APPINSIGHTS_IKEY = env('AZURE_APPINSIGHTS_IKEY', None)
 APPLICATION_INSIGHTS = {
     'ikey': AZURE_APPINSIGHTS_IKEY if AZURE_APPINSIGHTS_IKEY else None,
 }
-
-# work-around for django-heroku: don't overwrite sslmode outside of heroku
-if env.bool('IS_HEROKU', True):
-    django_heroku.settings(locals(), test_runner=False)
-
-# work-around for dj-database-url: explicitly disable ssl for sqlite
-if DATABASES['default'].get('ENGINE') == 'django.db.backends.sqlite3':
-    DATABASES['default'].get('OPTIONS', {}).pop('sslmode', None)

--- a/app/server/tests/test_config.py
+++ b/app/server/tests/test_config.py
@@ -16,9 +16,13 @@ class TestDatabaseUrl(TestCase):
         with setenv('DATABASE_URL', 'sqlite:///some/path'):
             self._assert_sslmode_is(None)
 
-    def test_sslmode_can_be_set_via_database_url(self):
+    def test_sslmode_can_be_disabled_via_database_url(self):
         with setenv('DATABASE_URL', 'pgsql://u:p@h/d?sslmode=disabled'):
             self._assert_sslmode_is('disabled')
+
+    def test_sslmode_can_be_required_via_database_url(self):
+        with setenv('DATABASE_URL', 'pgsql://u:p@h/d?sslmode=require'):
+            self._assert_sslmode_is('require')
 
     def _assert_sslmode_is(self, expected):
         reload(settings)

--- a/app/server/tests/test_config.py
+++ b/app/server/tests/test_config.py
@@ -17,8 +17,8 @@ class TestDatabaseUrl(TestCase):
             self._assert_sslmode_is(None)
 
     def test_sslmode_can_be_disabled_via_database_url(self):
-        with setenv('DATABASE_URL', 'pgsql://u:p@h/d?sslmode=disabled'):
-            self._assert_sslmode_is('disabled')
+        with setenv('DATABASE_URL', 'pgsql://u:p@h/d?sslmode=disable'):
+            self._assert_sslmode_is('disable')
 
     def test_sslmode_can_be_required_via_database_url(self):
         with setenv('DATABASE_URL', 'pgsql://u:p@h/d?sslmode=require'):

--- a/app/server/tests/test_config.py
+++ b/app/server/tests/test_config.py
@@ -1,0 +1,35 @@
+from contextlib import contextmanager
+from importlib import reload
+from os import environ
+
+from django.test import TestCase
+
+from app import settings
+
+
+class TestDatabaseUrl(TestCase):
+    def test_sslmode_defaults_to_required(self):
+        with setenv('DATABASE_URL', 'pgsql://u:p@h/d'):
+            self._assert_sslmode_is('require')
+
+    def test_sslmode_not_set_for_sqlite(self):
+        with setenv('DATABASE_URL', 'sqlite:///some/path'):
+            self._assert_sslmode_is(None)
+
+    def test_sslmode_can_be_set_via_database_url(self):
+        with setenv('DATABASE_URL', 'pgsql://u:p@h/d?sslmode=disabled'), \
+             setenv('IS_HEROKU', 'False'):
+            self._assert_sslmode_is('disabled')
+
+    def _assert_sslmode_is(self, expected):
+        reload(settings)
+        actual = settings.DATABASES['default'].get('OPTIONS', {}).get('sslmode')
+        self.assertEqual(actual, expected)
+
+
+@contextmanager
+def setenv(key, value):
+    environ[key] = value
+    yield
+    del environ[key]
+

--- a/app/server/tests/test_config.py
+++ b/app/server/tests/test_config.py
@@ -17,8 +17,7 @@ class TestDatabaseUrl(TestCase):
             self._assert_sslmode_is(None)
 
     def test_sslmode_can_be_set_via_database_url(self):
-        with setenv('DATABASE_URL', 'pgsql://u:p@h/d?sslmode=disabled'), \
-             setenv('IS_HEROKU', 'False'):
+        with setenv('DATABASE_URL', 'pgsql://u:p@h/d?sslmode=disabled'):
             self._assert_sslmode_is('disabled')
 
     def _assert_sslmode_is(self, expected):


### PR DESCRIPTION
There is an issue in [dj-database-url](https://pypi.org/project/dj-database-url/) which [always sets the sslmode even if the underlying engine doesn't support SSL](https://github.com/kennethreitz/dj-database-url/blob/v0.5.0/dj_database_url.py#L127-L128). See also the [conversation](https://github.com/chakki-works/doccano/pull/170#issuecomment-490023067) with @deltatree on https://github.com/chakki-works/doccano/pull/170 for more information.

There also is an issue in [django-heroku](https://pypi.org/project/django-heroku/) which seems to always override sslmode=True. See also the [conversation](https://github.com/chakki-works/doccano/pull/170#issuecomment-490543552) with @dveselov on https://github.com/chakki-works/doccano/pull/170 for more information.

This change implements a work-around for both behaviors.