### PR TITLE
Enhancement/Add button to delete documents on dataset page

### DIFF
--- a/app/server/static/js/dataset.js
+++ b/app/server/static/js/dataset.js
@@ -1,0 +1,8 @@
+import HTTP from './http';
+
+document.querySelectorAll('.delete-document-button').forEach((deleteButton) => {
+  deleteButton.addEventListener('click', () => {
+    const documentId = deleteButton.getAttribute('data-delete-document-id');
+    HTTP.delete(`docs/${documentId}`).then(() => window.location.reload());
+  });
+});

--- a/app/server/templates/dataset.html
+++ b/app/server/templates/dataset.html
@@ -17,6 +17,7 @@
         <tr>
           <th>#</th>
           <th>Text</th>
+          <th></th>
         </tr>
       </thead>
       <tbody>
@@ -24,6 +25,16 @@
         <tr>
           <td>{{ forloop.counter0|add:page_obj.start_index }}</td>
           <td>{{ doc.text|truncatechars:200 }}</td>
+          <td>
+            <p class="control">
+              <button class="button is-text delete-document-button" data-delete-document-id="{{ doc.id }}">
+                <span class="icon is-small">
+                  <i class="fas fa-trash"></i>
+                </span>
+                <span>Delete</span>
+              </button>
+            </p>
+          </td>
         </tr>
         {% endfor %}
       </tbody>

--- a/app/server/views.py
+++ b/app/server/views.py
@@ -34,6 +34,9 @@ class ProjectsView(LoginRequiredMixin, TemplateView):
 class DatasetView(SuperUserMixin, LoginRequiredMixin, ListView):
     template_name = 'dataset.html'
     paginate_by = 5
+    extra_context = {
+        'bundle_name': 'dataset'
+    }
 
     def get_queryset(self):
         project = get_object_or_404(Project, pk=self.kwargs['project_id'])

--- a/app/server/webpack.config.js
+++ b/app/server/webpack.config.js
@@ -16,6 +16,7 @@ module.exports = {
         'stats': './static/js/stats.js',
         'label': './static/js/label.js',
         'guideline': './static/js/guideline.js',
+        'dataset': './static/js/dataset.js',
         'demo_text_classification': './static/js/demo/demo_text_classification.js',
         'demo_named_entity': './static/js/demo/demo_named_entity.js',
         'demo_translation': './static/js/demo/demo_translation.js',


### PR DESCRIPTION
This change adds a button the the dataset page which lets an admin delete documents from a project. This is useful to for example delete test data or clean up the dataset.

The button is implemented via a simple request to the existing delete endpoint in the documents API. Given that the dataset page is server-side rendered by Django, when the request is successful, we reload the page to reflect the new state of the dataset. Note that for simplicity and speed, the button does not prompt the user for confirmation.

![Screenshot showing new document delete button](https://user-images.githubusercontent.com/1086421/57634825-132ec880-7574-11e9-8be0-3120e4145765.png)

Resolves https://github.com/chakki-works/doccano/issues/21
