### PR TITLE
Bugfix/Fix multiple display of completed items

### DIFF
--- a/app/server/filters.py
+++ b/app/server/filters.py
@@ -1,11 +1,23 @@
+from django.db.models import Count
 from django_filters.rest_framework import FilterSet, BooleanFilter
 from .models import Document
 
 
 class DocumentFilter(FilterSet):
-    seq_annotations__isnull = BooleanFilter(field_name='seq_annotations', lookup_expr='isnull')
-    doc_annotations__isnull = BooleanFilter(field_name='doc_annotations', lookup_expr='isnull')
-    seq2seq_annotations__isnull = BooleanFilter(field_name='seq2seq_annotations', lookup_expr='isnull')
+    seq_annotations__isnull = BooleanFilter(field_name='seq_annotations', method='filter_annotations')
+    doc_annotations__isnull = BooleanFilter(field_name='doc_annotations', method='filter_annotations')
+    seq2seq_annotations__isnull = BooleanFilter(field_name='seq2seq_annotations', method='filter_annotations')
+
+    def filter_annotations(self, queryset, field_name, value):
+        queryset = queryset.annotate(num_annotations=Count(field_name))
+
+        should_have_annotations = not value
+        if should_have_annotations:
+            queryset = queryset.filter(num_annotations__gte=1)
+        else:
+            queryset = queryset.filter(num_annotations__lte=0)
+
+        return queryset
 
     class Meta:
         model = Document


### PR DESCRIPTION
As discussed in https://github.com/chakki-works/doccano/issues/172, there is an issue in the completed filter where each document is included once per annotation in the document. See screenshot below for an example where a document is included 4 times in the list:

![Screenshot showing completed filter before fix](https://user-images.githubusercontent.com/1086421/57637028-6440bb80-7578-11e9-8e54-ef99bc2445ca.png)

The root cause of the problem is that the current filtering approach with `{column_name}__isnull` generates an inner join between the documents and annotations table which leads to the behavior of having one copy of the document per annotation.

This change fixes the behavior and ensures that each document is only included once in the completed list by using an explicit group by and count filter on the number of annotations:

![Screenshot showing completed filter after fix](https://user-images.githubusercontent.com/1086421/57642516-855bd900-7585-11e9-90f0-7f4c4e1f91bf.png)

Ideally we'd use `queryset.distinct('id')` instead of the group by count approach, but unfortunately this is currently only supported by Postgres.

Resolves https://github.com/chakki-works/doccano/issues/172