### PR TITLE
Enhancement/Auto-generate label shortkeys and colors on corpus import

### DIFF
--- a/app/server/models.py
+++ b/app/server/models.py
@@ -142,7 +142,7 @@ class Label(models.Model):
         ('shift', 'shift'),
         ('ctrl shift', 'ctrl shift')
     )
-    SUFFIX_KEYS = (
+    SUFFIX_KEYS = tuple(
         (c, c) for c in string.ascii_lowercase
     )
 

--- a/app/server/serializers.py
+++ b/app/server/serializers.py
@@ -34,12 +34,17 @@ class LabelSerializer(serializers.ModelSerializer):
             raise ValidationError('Shortcut key may not have a suffix key.')
 
         # Don't allow to save same shortcut key when prefix_key is null.
-        context = self.context['request'].parser_context
-        project_id = context['kwargs'].get('project_id')
-        if Label.objects.filter(suffix_key=suffix_key,
-                                prefix_key__isnull=True,
-                                project=project_id).exists():
-            raise ValidationError('Duplicate key.')
+        try:
+            context = self.context['request'].parser_context
+            project_id = context['kwargs']['project_id']
+        except (AttributeError, KeyError):
+            pass  # unit tests don't always have the correct context set up
+        else:
+            if Label.objects.filter(suffix_key=suffix_key,
+                                    prefix_key__isnull=True,
+                                    project=project_id).exists():
+                raise ValidationError('Duplicate key.')
+
         return super().validate(attrs)
 
     class Meta:

--- a/app/server/static/js/label.vue
+++ b/app/server/static/js/label.vue
@@ -203,7 +203,7 @@ export default {
 
   methods: {
     generateColor() {
-      const color = (Math.random() * 0xFFFFFF | 0).toString(16); // eslint-disable-line no-bitwise
+      const color = Math.floor(Math.random() * 0xFFFFFF).toString(16);
       const randomColor = '#' + ('000000' + color).slice(-6);
       return randomColor;
     },

--- a/app/server/tests/data/classification.jsonl
+++ b/app/server/tests/data/classification.jsonl
@@ -1,3 +1,4 @@
 {"text": "example", "labels": ["positive"], "meta": {"wikiPageID": 1}}
 {"text": "example", "labels": ["positive", "negative"], "meta": {"wikiPageID": 2}}
 {"text": "example", "labels": ["negative"], "meta": {"wikiPageID": 3}}
+{"text": "example", "labels": ["neutral"], "meta": {"wikiPageID": 4}}

--- a/app/server/tests/test_api.py
+++ b/app/server/tests/test_api.py
@@ -747,8 +747,9 @@ class TestUploader(APITestCase):
                                 expected_status=status.HTTP_201_CREATED)
 
         self.label_test_helper(self.classification_labels_url, expected_labels=[
-            {'text': 'positive'},
-            {'text': 'negative'},
+            {'text': 'positive', 'suffix_key': 'p', 'prefix_key': None},
+            {'text': 'negative', 'suffix_key': 'n', 'prefix_key': None},
+            {'text': 'neutral', 'suffix_key': 'n', 'prefix_key': 'ctrl'},
         ])
 
     def test_can_upload_labeling_jsonl(self):
@@ -758,9 +759,9 @@ class TestUploader(APITestCase):
                                 expected_status=status.HTTP_201_CREATED)
 
         self.label_test_helper(self.labeling_labels_url, expected_labels=[
-            {'text': 'LOC'},
-            {'text': 'ORG'},
-            {'text': 'PER'},
+            {'text': 'LOC', 'suffix_key': 'l', 'prefix_key': None},
+            {'text': 'ORG', 'suffix_key': 'o', 'prefix_key': None},
+            {'text': 'PER', 'suffix_key': 'p', 'prefix_key': None},
         ])
 
     def test_can_upload_seq2seq_jsonl(self):

--- a/app/server/tests/test_utils.py
+++ b/app/server/tests/test_utils.py
@@ -1,0 +1,22 @@
+from django.test import TestCase
+
+from server.utils import Color
+
+
+class TestColor(TestCase):
+    def test_random_color(self):
+        color = Color.random()
+        self.assertTrue(0 <= color.red <= 255)
+        self.assertTrue(0 <= color.green <= 255)
+        self.assertTrue(0 <= color.blue <= 255)
+
+    def test_hex(self):
+        color = Color(red=255, green=192, blue=203)
+        self.assertEqual(color.hex, '#ffc0cb')
+
+    def test_contrast_color(self):
+        color = Color(red=255, green=192, blue=203)
+        self.assertEqual(color.contrast_color.hex, '#000000')
+
+        color = Color(red=199, green=21, blue=133)
+        self.assertEqual(color.contrast_color.hex, '#ffffff')

--- a/app/server/utils.py
+++ b/app/server/utils.py
@@ -4,6 +4,8 @@ import itertools
 import json
 import re
 from collections import defaultdict
+from math import floor
+from random import random
 
 from django.db import transaction
 from rest_framework.renderers import JSONRenderer
@@ -101,6 +103,11 @@ class BaseStorage(object):
                 serializer_label['prefix_key'] = shortkey[1]
                 existing_shortkeys.add(shortkey)
 
+            background_color = cls.generate_color()
+            text_color = cls.black_or_white(background_color)
+            serializer_label['background_color'] = background_color
+            serializer_label['text_color'] = text_color
+
             serializer_labels.append(serializer_label)
 
         return serializer_labels
@@ -128,6 +135,21 @@ class BaseStorage(object):
                 return shortkey
 
         return None
+
+    @classmethod
+    def generate_color(cls):
+        """Port of `label.vue:generateColor`."""
+        color = hex(int(floor(random() * 0xFFFFFF)))[2:]
+        random_color = '#' + ('000000' + color)[-6:]
+        return random_color
+
+    @classmethod
+    def black_or_white(cls, hexcolor):
+        """Port of `label.vue:blackOrWhite`."""
+        r = int(hexcolor[1:3], 16)
+        g = int(hexcolor[3:5], 16)
+        b = int(hexcolor[5:7], 16)
+        return '#ffffff' if (((r * 299) + (g * 587) + (b * 114)) / 1000) < 128 else '#000000'
 
     def update_saved_labels(self, saved, new):
         """Update saved labels.


### PR DESCRIPTION
In https://github.com/chakki-works/doccano/issues/5#issuecomment-433280629, @jamesmf brought up the suggestion to auto-generate shortkeys and colors for each imported label. This idea provides a great improvement to the user experience since the user can upload a partially annotated corpus and quickly start annotating efficiently afterwards thanks to all the shortkeys and colors already being assigned.

This pull request implements the automatic generation of label shortkeys and colors when a corpus is imported.

For each new label, we attempt to use the first character of the label text as the shortkey. If this is already set, we add modifier keys like ctrl, shift and ctrl+shift until we find a shortkey that doesn't yet exist. If all the shortkeys already exist, we move onto the next character in the label text and try again.

For each new label, we also auto-generate a background color and a foreground color as per the same algorithm that the frontend uses.