### PR TITLE
Bugfix/Encode username in Azure DATABASE_URL

### DIFF
--- a/app/server/tests/test_config.py
+++ b/app/server/tests/test_config.py
@@ -29,12 +29,10 @@ class TestDatabaseUrl(TestCase):
             self._assert_user_is('user@host')
 
     def _assert_sslmode_is(self, expected):
-        reload(settings)
         actual = settings.DATABASES['default'].get('OPTIONS', {}).get('sslmode')
         self.assertEqual(actual, expected)
 
     def _assert_user_is(self, expected):
-        reload(settings)
         actual = settings.DATABASES['default'].get('USER', '')
         self.assertEqual(actual, expected)
 
@@ -42,6 +40,7 @@ class TestDatabaseUrl(TestCase):
 @contextmanager
 def setenv(key, value):
     environ[key] = value
+    reload(settings)
     yield
     del environ[key]
 

--- a/app/server/tests/test_config.py
+++ b/app/server/tests/test_config.py
@@ -24,9 +24,18 @@ class TestDatabaseUrl(TestCase):
         with setenv('DATABASE_URL', 'pgsql://u:p@h/d?sslmode=require'):
             self._assert_sslmode_is('require')
 
+    def test_database_url_with_complex_user(self):
+        with setenv('DATABASE_URL', 'pgsql://user%40host:p@h/d'):
+            self._assert_user_is('user@host')
+
     def _assert_sslmode_is(self, expected):
         reload(settings)
         actual = settings.DATABASES['default'].get('OPTIONS', {}).get('sslmode')
+        self.assertEqual(actual, expected)
+
+    def _assert_user_is(self, expected):
+        reload(settings)
+        actual = settings.DATABASES['default'].get('USER', '')
         self.assertEqual(actual, expected)
 
 

--- a/azuredeploy.json
+++ b/azuredeploy.json
@@ -97,7 +97,7 @@
     "databaseSkuTier": "GeneralPurpose",
     "databaseSkuFamily": "Gen5",
     "databaseSkuName": "[concat('GP_', variables('databaseSkuFamily'), '_', parameters('databaseCores'))]",
-    "databaseConnectionString": "[concat('pgsql://', parameters('adminUserName'), '@', variables('databaseServerName'), ':', parameters('adminPassword'), '@', variables('databaseServerName'), '.postgres.database.azure.com:5432/', parameters('databaseName'))]",
+    "databaseConnectionString": "[concat('pgsql://', parameters('adminUserName'), '%40', variables('databaseServerName'), ':', parameters('adminPassword'), '@', variables('databaseServerName'), '.postgres.database.azure.com:5432/', parameters('databaseName'))]",
     "databaseVersion": "9.6",
     "databaseServerName": "[concat(parameters('appName'),'-state')]",
     "setupScriptName": "[concat(parameters('appName'),'-setup')]",

--- a/azuredeploy.json
+++ b/azuredeploy.json
@@ -97,9 +97,12 @@
     "databaseSkuTier": "GeneralPurpose",
     "databaseSkuFamily": "Gen5",
     "databaseSkuName": "[concat('GP_', variables('databaseSkuFamily'), '_', parameters('databaseCores'))]",
-    "databaseConnectionString": "[concat('pgsql://', parameters('adminUserName'), '%40', variables('databaseServerName'), ':', parameters('adminPassword'), '@', variables('databaseServerName'), '.postgres.database.azure.com:5432/', parameters('databaseName'))]",
     "databaseVersion": "9.6",
+    "databaseServerPort": 5432,
     "databaseServerName": "[concat(parameters('appName'),'-state')]",
+    "databaseUserCredentials" : "[concat(uriComponent(concat(parameters('adminUserName'), '@', variables('databaseServerName'))), ':', parameters('adminPassword'))]",
+    "databaseFqdn" : "[concat( variables('databaseServerName'), '.postgres.database.azure.com:', variables('databaseServerPort'))]",
+    "databaseConnectionString": "[concat('pgsql://', variables('databaseUserCredentials'), '@', variables('databaseFqdn'), '/', parameters('databaseName'))]",
     "setupScriptName": "[concat(parameters('appName'),'-setup')]",
     "appServicePlanName": "[concat(parameters('appName'),'-hosting')]",
     "analyticsName": "[concat(parameters('appName'),'-analytics')]"
@@ -269,5 +272,11 @@
         "serverFarmId": "[resourceId('Microsoft.Web/serverfarms', variables('appServicePlanName'))]"
       }
     }
-  ]
+  ],
+  "outputs": {
+      "databaseServer": {
+          "type": "string",
+          "value": "[variables('databaseFqdn')]"
+        }
+  }
 }

--- a/azuredeploy.json
+++ b/azuredeploy.json
@@ -105,6 +105,7 @@
     "databaseConnectionString": "[concat('pgsql://', variables('databaseUserCredentials'), '@', variables('databaseFqdn'), '/', parameters('databaseName'))]",
     "setupScriptName": "[concat(parameters('appName'),'-setup')]",
     "appServicePlanName": "[concat(parameters('appName'),'-hosting')]",
+    "appFqdn": "[concat(parameters('appName'),'.azurewebsites.net')]",
     "analyticsName": "[concat(parameters('appName'),'-analytics')]"
   },
   "resources": [
@@ -274,6 +275,10 @@
     }
   ],
   "outputs": {
+    "appServer": {
+      "type": "string",
+      "value": "[concat(variables('appFqdn'))]"
+    },
     "databaseServer": {
       "type": "string",
       "value": "[variables('databaseFqdn')]"

--- a/azuredeploy.json
+++ b/azuredeploy.json
@@ -274,9 +274,9 @@
     }
   ],
   "outputs": {
-      "databaseServer": {
-          "type": "string",
-          "value": "[variables('databaseFqdn')]"
-        }
+    "databaseServer": {
+      "type": "string",
+      "value": "[variables('databaseFqdn')]"
+    }
   }
 }


### PR DESCRIPTION
In the Azure deploy the database user is in the format `user@server` and it looks like furl doesn't deal well with that. URL-encoding the `@` to `%40` fixes the problem.

Resolves https://github.com/chakki-works/doccano/issues/203