### PR TITLE
Enhancement/Speed up build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ services:
   - docker
 
 script:
-  - docker build .
+  - docker build --target=builder .
 
 deploy:
   - provider: script

--- a/Dockerfile
+++ b/Dockerfile
@@ -24,6 +24,9 @@ COPY . /doccano
 RUN cd /doccano \
  && tools/ci.sh
 
+RUN cd /doccano \
+ && python app/manage.py collectstatic --noinput
+
 RUN rm -rf /doccano/app/server/node_modules/
 
 FROM python:${PYTHON_VERSION}-slim AS runtime

--- a/Dockerfile
+++ b/Dockerfile
@@ -24,17 +24,22 @@ COPY . /doccano
 RUN cd /doccano \
  && tools/ci.sh
 
+FROM builder AS cleaner
+
 RUN cd /doccano \
  && python app/manage.py collectstatic --noinput
 
-RUN rm -rf /doccano/app/server/node_modules/
+RUN rm -rf /doccano/app/server/node_modules/ \
+ && rm -rf /doccano/app/server/static/ \
+ && rm -rf /doccano/app/staticfiles/js/ \
+ && find /doccano/app/staticfiles -type f -name '*.map*' -delete
 
 FROM python:${PYTHON_VERSION}-slim AS runtime
 
 COPY --from=builder /deps /deps
 RUN pip install --no-cache-dir /deps/*.whl
 
-COPY --from=builder /doccano /doccano
+COPY --from=cleaner /doccano /doccano
 
 ENV DEBUG="True"
 ENV SECRET_KEY="change-me-in-production"

--- a/app/app/settings.py
+++ b/app/app/settings.py
@@ -94,7 +94,13 @@ TEMPLATES = [
 ]
 
 STATICFILES_DIRS = [
-    path.join(BASE_DIR, 'server/static'),
+    static_path
+    for static_path in (
+        path.join(BASE_DIR, 'server', 'static', 'bundle'),
+        path.join(BASE_DIR, 'server', 'static', 'css'),
+        path.join(BASE_DIR, 'server', 'static', 'images'),
+    )
+    if path.isdir(static_path)
 ]
 
 STATICFILES_STORAGE = 'whitenoise.storage.CompressedManifestStaticFilesStorage'

--- a/app/server/tests/test_api.py
+++ b/app/server/tests/test_api.py
@@ -1,5 +1,6 @@
 import os
 
+from django.test import override_settings
 from rest_framework import status
 from rest_framework.reverse import reverse
 from rest_framework.test import APITestCase
@@ -11,6 +12,7 @@ from ..exceptions import FileParseException
 DATA_DIR = os.path.join(os.path.dirname(__file__), 'data')
 
 
+@override_settings(STATICFILES_STORAGE='django.contrib.staticfiles.storage.StaticFilesStorage')
 class TestProjectListAPI(APITestCase):
 
     @classmethod
@@ -70,6 +72,7 @@ class TestProjectListAPI(APITestCase):
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
 
 
+@override_settings(STATICFILES_STORAGE='django.contrib.staticfiles.storage.StaticFilesStorage')
 class TestProjectDetailAPI(APITestCase):
 
     @classmethod

--- a/app/server/tests/test_models.py
+++ b/app/server/tests/test_models.py
@@ -1,4 +1,4 @@
-from django.test import TestCase
+from django.test import TestCase, override_settings
 from django.core.exceptions import ValidationError
 from django.db.utils import IntegrityError
 from model_mommy import mommy
@@ -9,6 +9,7 @@ from ..serializers import SequenceAnnotationSerializer
 from ..serializers import Seq2seqAnnotationSerializer
 
 
+@override_settings(STATICFILES_STORAGE='django.contrib.staticfiles.storage.StaticFilesStorage')
 class TestTextClassificationProject(TestCase):
 
     @classmethod
@@ -32,6 +33,7 @@ class TestTextClassificationProject(TestCase):
         self.assertEqual(klass, DocumentAnnotation)
 
 
+@override_settings(STATICFILES_STORAGE='django.contrib.staticfiles.storage.StaticFilesStorage')
 class TestSequenceLabelingProject(TestCase):
 
     @classmethod
@@ -55,6 +57,7 @@ class TestSequenceLabelingProject(TestCase):
         self.assertEqual(klass, SequenceAnnotation)
 
 
+@override_settings(STATICFILES_STORAGE='django.contrib.staticfiles.storage.StaticFilesStorage')
 class TestSeq2seqProject(TestCase):
 
     @classmethod

--- a/tools/ci.sh
+++ b/tools/ci.sh
@@ -4,7 +4,6 @@ set -o errexit
 
 flake8
 python app/manage.py migrate
-python app/manage.py collectstatic
 python app/manage.py test server.tests
 
 (cd app/server && npm run lint)


### PR DESCRIPTION
This change makes various improvements to the Docker build in order to improve performance:

- Patch the static files storage for unit tests so that we can delay collectstatic until after running the tests.
- Build the full production image only during CD and not during CI.
- Reduce the static files scope to exclude the files only used by webpack.
- Introduce a new layer to remove build artifacts from the production image.

The overall impact of these changes is:

- For branches and pull requests, Docker build times are speed up by ~65% (as measured by `time`).
- For changes to master, Docker build times are sped up by ~15% (as measured by `time`).
- The final image is ~10% smaller (as measured by `docker image inspect`).
- The overall end-to-end time of the Travis build for this branch was ~4 minutes whereas for other branches build times around usually around ~8 minutes.
