### PR TITLE
Enhancement/Alignment for import data format and export data format

### DIFF
--- a/app/server/api.py
+++ b/app/server/api.py
@@ -209,13 +209,21 @@ class TextDownloadAPI(APIView):
         project = get_object_or_404(Project, pk=self.kwargs['project_id'])
         documents = project.documents.all()
         painter = self.select_painter(format)
-        data = painter.paint(documents)
+        
+        # json1 format prints text labels while json format prints annotations with label ids
+		# json1 format - "labels": [[0, 15, "PERSON"], ..]
+		# json format  "annotations": [{"label": 5, "start_offset": 0, "end_offset": 2, "user": 1},..]
+        if format == "json1":
+            labels = project.labels.all()
+            data = painter.paint_labels(documents, labels)
+        else:
+            data = painter.paint(documents)
         return Response(data)
 
     def select_painter(self, format):
         if format == 'csv':
             return CSVPainter()
-        elif format == 'json':
+        elif format == 'json' or format == "json1":
             return JSONPainter()
         else:
             raise ValidationError('format {} is invalid.'.format(format))

--- a/app/server/api.py
+++ b/app/server/api.py
@@ -211,8 +211,8 @@ class TextDownloadAPI(APIView):
         painter = self.select_painter(format)
         
         # json1 format prints text labels while json format prints annotations with label ids
-		# json1 format - "labels": [[0, 15, "PERSON"], ..]
-		# json format  "annotations": [{"label": 5, "start_offset": 0, "end_offset": 2, "user": 1},..]
+        # json1 format - "labels": [[0, 15, "PERSON"], ..]
+        # json format - "annotations": [{"label": 5, "start_offset": 0, "end_offset": 2, "user": 1},..]
         if format == "json1":
             labels = project.labels.all()
             data = painter.paint_labels(documents, labels)

--- a/app/server/static/js/download_sequence_labeling.vue
+++ b/app/server/static/js/download_sequence_labeling.vue
@@ -12,11 +12,29 @@ block select-format-area
     )
     | JSONL
 
+  label.radio
+    input(
+      type="radio"
+      name="format"
+      value="json1"
+      v-bind:checked="format == 'json1'"
+      v-model="format"
+    )
+    | JSON(Text-Labels)
+
+
 block example-format-area
   pre.code-block(v-show="format == 'json'")
     code.json
       include ./examples/download_sequence_labeling.jsonl
       | ...
+  pre.code-block(v-show="format == 'json1'")
+    code.json
+      include ./examples/download_sequence_labeling.json1l
+      | ...
+</template>
+
+
 </template>
 
 <script>

--- a/app/server/static/js/download_sequence_labeling.vue
+++ b/app/server/static/js/download_sequence_labeling.vue
@@ -22,7 +22,6 @@ block select-format-area
     )
     | JSON(Text-Labels)
 
-
 block example-format-area
   pre.code-block(v-show="format == 'json'")
     code.json
@@ -32,9 +31,6 @@ block example-format-area
     code.json
       include ./examples/download_sequence_labeling.json1l
       | ...
-</template>
-
-
 </template>
 
 <script>

--- a/app/server/static/js/download_sequence_labeling.vue
+++ b/app/server/static/js/download_sequence_labeling.vue
@@ -27,6 +27,7 @@ block example-format-area
     code.json
       include ./examples/download_sequence_labeling.jsonl
       | ...
+
   pre.code-block(v-show="format == 'json1'")
     code.json
       include ./examples/download_sequence_labeling.json1l

--- a/app/server/static/js/examples/download_sequence_labeling.json1l
+++ b/app/server/static/js/examples/download_sequence_labeling.json1l
@@ -1,0 +1,3 @@
+{"id": 1, "text": "EU rejects ...", "labels": [[0,2,"ORG"], [11,17, "MISC"], [34,41,"ORG"]]}
+{"id": 2, "text": "Peter Blackburn", "labels": [[0, 15, "PERSON"]]}
+{"id": 3, "text": "President Obama", "labels": [[10, 15, "PERSON"]]}

--- a/app/server/tests/test_api.py
+++ b/app/server/tests/test_api.py
@@ -904,6 +904,11 @@ class TestDownloader(APITestCase):
                                   format='json',
                                   expected_status=status.HTTP_200_OK)
 
+    def test_can_download_labelling_json1(self):
+        self.download_test_helper(url=self.labeling_url,
+                                  format='json1',
+                                  expected_status=status.HTTP_200_OK)    
+
     def test_can_download_plain_text(self):
         self.download_test_helper(url=self.classification_url,
                                   format='plain',

--- a/app/server/tests/test_utils.py
+++ b/app/server/tests/test_utils.py
@@ -1,6 +1,10 @@
 from django.test import TestCase
 
-from server.utils import Color
+from seqeval.metrics.sequence_labeling import get_entities
+
+from ..models import Label, Document
+from ..utils import BaseStorage, ClassificationStorage, SequenceLabelingStorage, Seq2seqStorage, CoNLLParser
+from ..utils import Color
 
 
 class TestColor(TestCase):
@@ -20,3 +24,132 @@ class TestColor(TestCase):
 
         color = Color(red=199, green=21, blue=133)
         self.assertEqual(color.contrast_color.hex, '#ffffff')
+
+
+class TestBaseStorage(TestCase):
+    def test_extract_label(self):
+        data = [{'labels': ['positive']}, {'labels': ['negative']}]
+
+        actual = BaseStorage.extract_label(data)
+
+        self.assertEqual(actual, [['positive'], ['negative']])
+
+    def test_exclude_created_labels(self):
+        labels = ['positive', 'negative']
+        created = {'positive': Label(text='positive')}
+
+        actual = BaseStorage.exclude_created_labels(labels, created)
+
+        self.assertEqual(actual, ['negative'])
+
+    def test_to_serializer_format(self):
+        labels = ['positive']
+        created = {}
+
+        actual = BaseStorage.to_serializer_format(labels, created, random_seed=123)
+
+        self.assertEqual(actual, [{
+            'text': 'positive',
+            'prefix_key': None,
+            'suffix_key': 'p',
+            'background_color': '#0d1668',
+            'text_color': '#ffffff',
+        }])
+
+    def test_get_shortkey_without_existing_shortkey(self):
+        label = 'positive'
+        created = {}
+
+        actual = BaseStorage.get_shortkey(label, created)
+
+        self.assertEqual(actual, ('p', None))
+
+    def test_get_shortkey_with_existing_shortkey(self):
+        label = 'positive'
+        created = {('p', None)}
+
+        actual = BaseStorage.get_shortkey(label, created)
+
+        self.assertEqual(actual, ('p', 'ctrl'))
+
+    def test_update_saved_labels(self):
+        saved = {'positive': Label(text='positive', text_color='#000000')}
+        new = [Label(text='positive', text_color='#ffffff')]
+
+        actual = BaseStorage.update_saved_labels(saved, new)
+
+        self.assertEqual(actual['positive'].text_color, '#ffffff')
+
+
+class TestClassificationStorage(TestCase):
+    def test_extract_unique_labels(self):
+        labels = [['positive'], ['positive', 'negative'], ['negative']]
+
+        actual = ClassificationStorage.extract_unique_labels(labels)
+
+        self.assertCountEqual(actual, ['positive', 'negative'])
+
+    def test_make_annotations(self):
+        docs = [Document(text='a', id=1), Document(text='b', id=2), Document(text='c', id=3)]
+        labels = [['positive'], ['positive', 'negative'], ['negative']]
+        saved_labels = {'positive': Label(text='positive', id=1), 'negative': Label(text='negative', id=2)}
+
+        actual = ClassificationStorage.make_annotations(docs, labels, saved_labels)
+
+        self.assertCountEqual(actual, [
+            {'document': 1, 'label': 1},
+            {'document': 2, 'label': 1},
+            {'document': 2, 'label': 2},
+            {'document': 3, 'label': 2},
+        ])
+
+
+class TestSequenceLabelingStorage(TestCase):
+    def test_extract_unique_labels(self):
+        labels = [[[0, 1, 'LOC']], [[3, 4, 'ORG']]]
+
+        actual = SequenceLabelingStorage.extract_unique_labels(labels)
+
+        self.assertCountEqual(actual, ['LOC', 'ORG'])
+
+    def test_make_annotations(self):
+        docs = [Document(text='a', id=1), Document(text='b', id=2)]
+        labels = [[[0, 1, 'LOC']], [[3, 4, 'ORG']]]
+        saved_labels = {'LOC': Label(text='LOC', id=1), 'ORG': Label(text='ORG', id=2)}
+
+        actual = SequenceLabelingStorage.make_annotations(docs, labels, saved_labels)
+
+        self.assertEqual(actual, [
+            {'document': 1, 'label': 1, 'start_offset': 0, 'end_offset': 1},
+            {'document': 2, 'label': 2, 'start_offset': 3, 'end_offset': 4},
+        ])
+
+
+class TestSeq2seqStorage(TestCase):
+    def test_make_annotations(self):
+        docs = [Document(text='a', id=1), Document(text='b', id=2)]
+        labels = [['Hello!'], ['How are you?', "What's up?"]]
+
+        actual = Seq2seqStorage.make_annotations(docs, labels)
+
+        self.assertEqual(actual, [
+            {'document': 1, 'text': 'Hello!'},
+            {'document': 2, 'text': 'How are you?'},
+            {'document': 2, 'text': "What's up?"},
+        ])
+
+
+class TestCoNLLParser(TestCase):
+    def test_calc_char_offset(self):
+        words = ['EU', 'rejects', 'German', 'call']
+        tags = ['B-ORG', 'O', 'B-MISC', 'O']
+
+        entities = get_entities(tags)
+        actual = CoNLLParser.calc_char_offset(words, tags)
+
+        self.assertEqual(entities, [('ORG', 0, 0), ('MISC', 2, 2)])
+
+        self.assertEqual(actual, {
+            'text': 'EU rejects German call',
+            'labels': [[0, 2, 'ORG'], [11, 17, 'MISC']]
+        })

--- a/app/server/utils.py
+++ b/app/server/utils.py
@@ -349,7 +349,8 @@ class JSONParser(FileParser):
                 yield data
                 data = []
             try:
-                j = json.loads(line)
+                #j = json.loads(line)
+                j  = json.loads(line.decode('utf-8'))
                 j['meta'] = json.dumps(j.get('meta', {}))
                 data.append(j)
             except json.decoder.JSONDecodeError:
@@ -376,7 +377,6 @@ class JSONLRenderer(JSONRenderer):
                              ensure_ascii=self.ensure_ascii,
                              allow_nan=not self.strict) + '\n'
 
-
 class JSONPainter(object):
 
     def paint(self, documents):
@@ -388,6 +388,24 @@ class JSONPainter(object):
                 a.pop('id')
                 a.pop('prob')
                 a.pop('document')
+            data.append(d)
+        return data
+
+    def paint_labels(self, documents, labels):
+        serializer_labels = LabelSerializer(labels, many = True)
+        serializer = DocumentSerializer(documents, many=True)
+        data = []
+        for d in serializer.data:
+            labels = []
+            for a in d['annotations']:
+                label_obj = [x for x in serializer_labels.data if x['id'] == a['label']][0]
+                label_text = label_obj['text']
+                label_start = a['start_offset']
+                label_end = a['end_offset']
+                labels. append([label_start, label_end, label_text])
+            d.pop('annotations')
+            d['labels'] = labels
+            d['meta'] = json.loads(d['meta'])
             data.append(d)
         return data
 

--- a/app/server/utils.py
+++ b/app/server/utils.py
@@ -351,7 +351,6 @@ class JSONParser(FileParser):
                 data = []
             try:
                 j = json.loads(line)
-                #j  = json.loads(line.decode('utf-8'))
                 j['meta'] = json.dumps(j.get('meta', {}))
                 data.append(j)
             except json.decoder.JSONDecodeError:

--- a/app/server/utils.py
+++ b/app/server/utils.py
@@ -343,14 +343,15 @@ class CSVParser(FileParser):
 class JSONParser(FileParser):
 
     def parse(self, file):
+        file = io.TextIOWrapper(file, encoding='utf-8')
         data = []
         for i, line in enumerate(file, start=1):
             if len(data) >= IMPORT_BATCH_SIZE:
                 yield data
                 data = []
             try:
-                #j = json.loads(line)
-                j  = json.loads(line.decode('utf-8'))
+                j = json.loads(line)
+                #j  = json.loads(line.decode('utf-8'))
                 j['meta'] = json.dumps(j.get('meta', {}))
                 data.append(j)
             except json.decoder.JSONDecodeError:
@@ -392,7 +393,7 @@ class JSONPainter(object):
         return data
 
     def paint_labels(self, documents, labels):
-        serializer_labels = LabelSerializer(labels, many = True)
+        serializer_labels = LabelSerializer(labels, many=True)
         serializer = DocumentSerializer(documents, many=True)
         data = []
         for d in serializer.data:
@@ -402,7 +403,7 @@ class JSONPainter(object):
                 label_text = label_obj['text']
                 label_start = a['start_offset']
                 label_end = a['end_offset']
-                labels. append([label_start, label_end, label_text])
+                labels.append([label_start, label_end, label_text])
             d.pop('annotations')
             d['labels'] = labels
             d['meta'] = json.loads(d['meta'])


### PR DESCRIPTION
Currently, the annotated file exported from doccano cannot be imported back into doccano for further validation or annotation because of a misalignment in the import and export formats described here (https://github.com/chakki-works/doccano/issues/113). 

This PR addresses this by adding a new export option that allows the users to export the annotated file with text labels that allows for this to be re-imported into doccano. The feature preview is shown below:
![image](https://user-images.githubusercontent.com/9581213/58054818-a6d23d00-7b10-11e9-86f5-0753ad415900.png)

The original export functionality is maintained as it contains user details for each annotation that is used in inter-annotator analyses.
