### PR TITLE
Bugfix/Make menu responsive

### DIFF
--- a/app/server/static/assets/css/forum.css
+++ b/app/server/static/assets/css/forum.css
@@ -31,8 +31,29 @@ strong {
   box-shadow: 0 1px 4px rgba(0, 0, 0, .3);
 }
 
+.navbar-burger,
 .navbar-item {
   color: white;
+}
+
+a.navbar-burger:hover {
+  background-color: #fafafa;
+  color: #3273dc;
+}
+
+.navbar-menu.is-active .navbar-item,
+.navbar-menu.is-active .navbar-link {
+  color: #4a4a4a;
+}
+
+.navbar-menu.is-active .navbar-dropdown .navbar-item {
+  color: #fafafa;
+}
+
+.navbar-menu.is-active .navbar-dropdown .navbar-item:hover,
+.navbar-menu.is-active .navbar-item:hover,
+.navbar-menu.is-active .navbar-link:hover {
+  color: #3273dc;
 }
 
 .topNav {

--- a/app/server/static/pages/index.js
+++ b/app/server/static/pages/index.js
@@ -12,3 +12,19 @@ new Swiper('.swiper-container', {
     prevEl: '.swiper-button-prev',
   },
 });
+
+document.addEventListener('DOMContentLoaded', () => {
+  const $navbarBurgers = Array.prototype.slice.call(document.querySelectorAll('.navbar-burger'), 0);
+
+  if ($navbarBurgers.length > 0) {
+    $navbarBurgers.forEach((el) => {
+      el.addEventListener('click', () => {
+        const target = el.dataset.target;
+        const $target = document.getElementById(target);
+
+        el.classList.toggle('is-active');
+        $target.classList.toggle('is-active');
+      });
+    });
+  }
+});

--- a/app/server/templates/base.html
+++ b/app/server/templates/base.html
@@ -46,6 +46,11 @@
           <img src="{% static 'assets/images/logo.png' %}" width="32" height="32">
           <b>doccano</b>
         </a>
+        <a role="button" class="navbar-burger burger" aria-label="menu" aria-expanded="false" data-target="topNav">
+          <span aria-hidden="true"></span>
+          <span aria-hidden="true"></span>
+          <span aria-hidden="true"></span>
+        </a>
         {% block navigation %}{% endblock %}
       </div>
       <div id="topNav" class="navbar-menu">


### PR DESCRIPTION
Currently the navbar items disappear on screens less than ~1000px wide which means the user can't access functionality such as log-out or going to the projects page.

This pull request ensures that the navbar items are available on all screen sizes by collapsing the items into a hamburger menu on small screens. The Javascript for the functionality is taken from the [Bulma docs](https://bulma.io/documentation/components/navbar/#navbarJsExample).

**Responsive nav for logged-out user**

![Responsive menu for logged-out user](https://user-images.githubusercontent.com/1086421/58580112-5ea2d100-821a-11e9-8a2e-3fa6d84a3af3.gif)

**Responsive nav for logged-in user**

![Responsive menu for logged-in user](https://user-images.githubusercontent.com/1086421/58580113-5ea2d100-821a-11e9-976d-bc6cc5436f44.gif)
