### PR TITLE
Feature/Filter the progress bar & document list by a user's own annotations

### DIFF
--- a/app/server/api.py
+++ b/app/server/api.py
@@ -67,7 +67,8 @@ class StatisticsAPI(APIView):
         docs = project.documents
         annotation_class = project.get_annotation_class()
         total = docs.count()
-        done = annotation_class.objects.filter(document_id__in=docs.all()).\
+        done = annotation_class.objects.filter(document_id__in=docs.all(),
+            user_id=self.request.user).\
             aggregate(Count('document', distinct=True))['document__count']
         remaining = total - done
         return {'total': total, 'remaining': remaining}

--- a/app/server/filters.py
+++ b/app/server/filters.py
@@ -1,4 +1,4 @@
-from django.db.models import Count
+from django.db.models import Count, Q
 from django_filters.rest_framework import FilterSet, BooleanFilter
 from .models import Document
 
@@ -9,7 +9,9 @@ class DocumentFilter(FilterSet):
     seq2seq_annotations__isnull = BooleanFilter(field_name='seq2seq_annotations', method='filter_annotations')
 
     def filter_annotations(self, queryset, field_name, value):
-        queryset = queryset.annotate(num_annotations=Count(field_name))
+        queryset = queryset.annotate(num_annotations=
+            Count(field_name, filter=
+                Q(**{ f"{field_name}__user": self.request.user})))
 
         should_have_annotations = not value
         if should_have_annotations:

--- a/app/server/tests/test_api.py
+++ b/app/server/tests/test_api.py
@@ -933,7 +933,7 @@ class TestStatisticsAPI(APITestCase):
         main_project = mommy.make('server.TextClassificationProject', users=[super_user])
         doc1 = mommy.make('server.Document', project=main_project)
         doc2 = mommy.make('server.Document', project=main_project)
-        mommy.make('DocumentAnnotation', document=doc1)
+        mommy.make('DocumentAnnotation', document=doc1, user=super_user)
         cls.url = reverse(viewname='statistics', args=[main_project.id])
         cls.doc = Document.objects.filter(project=main_project)
 


### PR DESCRIPTION
We're using Doccano to collect annotations from multiple people per document. We've found it confusing that the progress bar and document filter on the annotation page includes annotations for **all** users instead of just the current user.

This PR makes two key changes:

1. it updates the progress API end point to only count annotations for the logged in user
2. It updates the document filter to count annotations for the logged in user