### PR TITLE
we add some columns to the admin page

### DIFF
--- a/app/server/admin.py
+++ b/app/server/admin.py
@@ -6,41 +6,47 @@ from .models import TextClassificationProject, SequenceLabelingProject, Seq2seqP
 
 
 class LabelAdmin(admin.ModelAdmin):
-    list_display = ('text', 'project','text_color','background_color')
+    list_display = ('text', 'project', 'text_color', 'background_color')
     ordering = ('project',)
     search_fields = ('project',)
+
 
 class DocumentAdmin(admin.ModelAdmin):
-    list_display = ('text', 'project','meta')
+    list_display = ('text', 'project', 'meta')
     ordering = ('project',)
     search_fields = ('project',)
 
+
 class ProjectAdmin(admin.ModelAdmin):
-    list_display = ('name', 'description','project_type','randomize_document_order')
+    list_display = ('name', 'description', 'project_type', 'randomize_document_order')
     ordering = ('project_type',)
     search_fields = ('name',)
 
+
 class SequenceAnnotationAdmin(admin.ModelAdmin):
-    list_display = ('document', 'label','start_offset','user')
+    list_display = ('document', 'label', 'start_offset', 'user')
     ordering = ('document',)
     search_fields = ('document',)
+
 
 class DocumentAnnotationAdmin(admin.ModelAdmin):
-    list_display = ('document', 'label','user')
+    list_display = ('document', 'label', 'user')
     ordering = ('document',)
     search_fields = ('document',)
+
 
 class Seq2seqAnnotationAdmin(admin.ModelAdmin):
-    list_display = ('document', 'text','user')
+    list_display = ('document', 'text', 'user')
     ordering = ('document',)
     search_fields = ('document',)
 
-admin.site.register(DocumentAnnotation,DocumentAnnotationAdmin)
-admin.site.register(SequenceAnnotation,SequenceAnnotationAdmin)
-admin.site.register(Seq2seqAnnotation,Seq2seqAnnotationAdmin)
-admin.site.register(Label,LabelAdmin)
-admin.site.register(Document,DocumentAdmin)
-admin.site.register(Project,ProjectAdmin)
-admin.site.register(TextClassificationProject,ProjectAdmin)
-admin.site.register(SequenceLabelingProject,ProjectAdmin)
-admin.site.register(Seq2seqProject,ProjectAdmin)
+
+admin.site.register(DocumentAnnotation, DocumentAnnotationAdmin)
+admin.site.register(SequenceAnnotation, SequenceAnnotationAdmin)
+admin.site.register(Seq2seqAnnotation, Seq2seqAnnotationAdmin)
+admin.site.register(Label, LabelAdmin)
+admin.site.register(Document, DocumentAdmin)
+admin.site.register(Project, ProjectAdmin)
+admin.site.register(TextClassificationProject, ProjectAdmin)
+admin.site.register(SequenceLabelingProject, ProjectAdmin)
+admin.site.register(Seq2seqProject, ProjectAdmin)

--- a/app/server/admin.py
+++ b/app/server/admin.py
@@ -4,12 +4,43 @@ from .models import Label, Document, Project
 from .models import DocumentAnnotation, SequenceAnnotation, Seq2seqAnnotation
 from .models import TextClassificationProject, SequenceLabelingProject, Seq2seqProject
 
-admin.site.register(DocumentAnnotation)
-admin.site.register(SequenceAnnotation)
-admin.site.register(Seq2seqAnnotation)
-admin.site.register(Label)
-admin.site.register(Document)
-admin.site.register(Project)
-admin.site.register(TextClassificationProject)
-admin.site.register(SequenceLabelingProject)
-admin.site.register(Seq2seqProject)
+
+class LabelAdmin(admin.ModelAdmin):
+    list_display = ('text', 'project','text_color','background_color')
+    ordering = ('project',)
+    search_fields = ('project',)
+
+class DocumentAdmin(admin.ModelAdmin):
+    list_display = ('text', 'project','meta')
+    ordering = ('project',)
+    search_fields = ('project',)
+
+class ProjectAdmin(admin.ModelAdmin):
+    list_display = ('name', 'description','project_type','randomize_document_order')
+    ordering = ('project_type',)
+    search_fields = ('name',)
+
+class SequenceAnnotationAdmin(admin.ModelAdmin):
+    list_display = ('document', 'label','start_offset','user')
+    ordering = ('document',)
+    search_fields = ('document',)
+
+class DocumentAnnotationAdmin(admin.ModelAdmin):
+    list_display = ('document', 'label','user')
+    ordering = ('document',)
+    search_fields = ('document',)
+
+class Seq2seqAnnotationAdmin(admin.ModelAdmin):
+    list_display = ('document', 'text','user')
+    ordering = ('document',)
+    search_fields = ('document',)
+
+admin.site.register(DocumentAnnotation,DocumentAnnotationAdmin)
+admin.site.register(SequenceAnnotation,SequenceAnnotationAdmin)
+admin.site.register(Seq2seqAnnotation,Seq2seqAnnotationAdmin)
+admin.site.register(Label,LabelAdmin)
+admin.site.register(Document,DocumentAdmin)
+admin.site.register(Project,ProjectAdmin)
+admin.site.register(TextClassificationProject,ProjectAdmin)
+admin.site.register(SequenceLabelingProject,ProjectAdmin)
+admin.site.register(Seq2seqProject,ProjectAdmin)


### PR DESCRIPTION
We **add some columns to the admin page** in order to have a better overview of the table's elements. Nothing big, just a first simple pull request.

- This way, we can see some important features while browsing the admin.

- We also see the element sorted out

- We give the opportunity to search through the elements