### PR TITLE
Bugfix/wrong lable

### DIFF
--- a/app/server/utils.py
+++ b/app/server/utils.py
@@ -274,7 +274,7 @@ class CoNLLParser(FileParser):
         pos = defaultdict(int)
         for label, start_offset, end_offset in get_entities(tags):
             entity = ' '.join(words[start_offset: end_offset + 1])
-            char_left = doc.index(entity, pos[entity])
+            char_left = start_offset * 2;
             char_right = char_left + len(entity)
             span = [char_left, char_right, label]
             j['labels'].append(span)


### PR DESCRIPTION
if use doc.index() to find text position, when this entity is appeared before this words, we find wrong position.