### PR TITLE
Bugfix/Document libpq dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,7 @@ docker pull chakkiworks/doccano
 First we need to install the dependencies. Run the following commands:
 
 ```bash
+sudo apt-get install libpq-dev
 pip install -r requirements.txt
 cd app
 ```


### PR DESCRIPTION
As mentioned in https://github.com/chakki-works/doccano/issues/263, we should document the transitive dependency on `libpq-dev` (via django-heroku's dependency on `psycopg2`).