### PR TITLE
Enhancement/Avoid running docker image as root

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,18 +29,21 @@ RUN cd /doccano \
 
 FROM python:${PYTHON_VERSION}-slim AS runtime
 
+RUN useradd -ms /bin/sh doccano
+
 COPY --from=builder /deps /deps
 RUN pip install --no-cache-dir /deps/*.whl
 
-COPY --from=cleaner /doccano /doccano
+COPY --from=cleaner --chown=doccano:doccano /doccano /doccano
 
 ENV DEBUG="True"
 ENV SECRET_KEY="change-me-in-production"
-ENV PORT="80"
+ENV PORT="8000"
 ENV WORKERS="2"
 ENV GOOGLE_TRACKING_ID=""
 ENV AZURE_APPINSIGHTS_IKEY=""
 
+USER doccano
 WORKDIR /doccano
 EXPOSE ${PORT}
 

--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ Depending on your installation method, there are two options:
 First, run a Docker container:
 
 ```bash
-docker run -d --name doccano -p 8000:80 chakkiworks/doccano
+docker run -d --name doccano -p 8000:8000 chakkiworks/doccano
 ```
 
 Then, execute `create-admin.sh` script for creating a superuser.

--- a/azuredeploy.json
+++ b/azuredeploy.json
@@ -272,6 +272,14 @@
           "alwaysOn": true,
           "appSettings": [
             {
+              "name": "WEBSITES_PORT",
+              "value": "8000"
+            },
+            {
+              "name": "PORT",
+              "value": "8000"
+            },
+            {
               "name": "WEBSITES_ENABLE_APP_SERVICE_STORAGE",
               "value": "false"
             },


### PR DESCRIPTION
It's generally considered a [Docker security best practice](https://snyk.io/blog/10-docker-image-security-best-practices/) to use a non-root user in the container at runtime. As such, this pull request introduces a non-privileged user to the Dockerfile to run the Doccano container.