### PR TITLE
Enhancement/Simplify queryset handling in list APIs

### DIFF
--- a/app/api/views.py
+++ b/app/api/views.py
@@ -42,7 +42,6 @@ class Features(APIView):
 
 
 class ProjectList(generics.ListCreateAPIView):
-    queryset = Project.objects.all()
     serializer_class = ProjectPolymorphicSerializer
     pagination_class = None
     permission_classes = (IsAuthenticated, IsAdminUserAndWriteOnly)
@@ -109,14 +108,13 @@ class ApproveLabelsAPI(APIView):
 
 
 class LabelList(generics.ListCreateAPIView):
-    queryset = Label.objects.all()
     serializer_class = LabelSerializer
     pagination_class = None
     permission_classes = (IsAuthenticated, IsProjectUser, IsAdminUserAndWriteOnly)
 
     def get_queryset(self):
-        queryset = self.queryset.filter(project=self.kwargs['project_id'])
-        return queryset
+        project = get_object_or_404(Project, pk=self.kwargs['project_id'])
+        return project.labels
 
     def perform_create(self, serializer):
         project = get_object_or_404(Project, pk=self.kwargs['project_id'])
@@ -131,7 +129,6 @@ class LabelDetail(generics.RetrieveUpdateDestroyAPIView):
 
 
 class DocumentList(generics.ListCreateAPIView):
-    queryset = Document.objects.all()
     serializer_class = DocumentSerializer
     filter_backends = (DjangoFilterBackend, filters.SearchFilter, filters.OrderingFilter)
     search_fields = ('text', )
@@ -143,7 +140,7 @@ class DocumentList(generics.ListCreateAPIView):
     def get_queryset(self):
         project = get_object_or_404(Project, pk=self.kwargs['project_id'])
 
-        queryset = self.queryset.filter(project=project)
+        queryset = project.documents
 
         if project.randomize_document_order:
             queryset = queryset.annotate(sort_id=F('id') % self.request.user.id).order_by('sort_id')


### PR DESCRIPTION
Currently there are several list APIs that define both `queryset` and `get_queryset` which can be confusing to new developers. This pull request cleans up the list APIs such that only one of `queryset` or `get_queryset` always is used.