### PR TITLE
Enhancement/Test production databases

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,14 +3,30 @@ language: python
 python:
   - "3.6"
 
+env:
+  - DATABASE=sqlite
+  - DATABASE=postgres
+
 services:
   - docker
+
+before_install:
+  - docker network create doccano
+  - >
+    if [[ "${DATABASE}" = "postgres" ]]; then
+      docker run --rm --name=postgres --network=doccano -d -e POSTGRES_USER=user -e POSTGRES_PASSWORD=pass -e POSTGRES_DB=db postgres
+      export DATABASE_URL="postgres://user:pass@postgres:5432/db?sslmode=disable"
+    fi
 
 install:
     - pip install mkdocs mkdocs-material
 
 script:
-  - docker build --target=builder .
+  - docker build --target=builder --tag=doccano-test .
+  - >
+    if [[ "${DATABASE}" != "sqlite" ]]; then
+      docker run --network doccano -e DATABASE_URL="${DATABASE_URL}" -it doccano-test sh -c 'app/manage.py migrate && app/manage.py test api.tests server.tests'
+    fi
 
 before_deploy:
     - mkdocs build --verbose --clean

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,8 +15,8 @@ RUN pip install -r /requirements.txt \
 
 COPY . /doccano
 
-RUN cd /doccano \
- && tools/ci.sh
+WORKDIR /doccano
+RUN tools/ci.sh
 
 FROM builder AS cleaner
 


### PR DESCRIPTION
Currently in the CI we only run tests against SQLite. However, doccano also supports other databases such as Postgres. In order to ensure that all the databases keep working, this pull request adds a CI step that runs the test suite against non-SQLite databases.

The approach introduced in this pull request also makes it easy to verify new database backends such as SQL Server (see https://github.com/chakki-works/doccano/pull/255).