### PR TITLE
Bugfix/Sequence to sequence: cannot download labels 

### DIFF
--- a/app/api/serializers.py
+++ b/app/api/serializers.py
@@ -160,5 +160,5 @@ class Seq2seqAnnotationSerializer(serializers.ModelSerializer):
 
     class Meta:
         model = Seq2seqAnnotation
-        fields = ('id', 'text', 'user', 'document')
+        fields = ('id', 'text', 'user', 'document', 'prob')
         read_only_fields = ('user',)

--- a/app/api/utils.py
+++ b/app/api/utils.py
@@ -373,6 +373,7 @@ class JSONLRenderer(JSONRenderer):
                              ensure_ascii=self.ensure_ascii,
                              allow_nan=not self.strict) + '\n'
 
+
 class JSONPainter(object):
 
     def paint(self, documents):
@@ -405,6 +406,7 @@ class JSONPainter(object):
             d['meta'] = json.loads(d['meta'])
             data.append(d)
         return data
+
 
 class CSVPainter(JSONPainter):
 


### PR DESCRIPTION
Addresses issue #268 
- Fixes progress bar so that it shows number of labelled documents for seq2seq.
- Added field to allow for seq2seq export.