### PR TITLE
Bugfix/Pin Python base image to Debian stretch

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 ARG PYTHON_VERSION="3.6"
-FROM python:${PYTHON_VERSION} AS builder
+FROM python:${PYTHON_VERSION}-stretch AS builder
 
 ARG NODE_VERSION="8.x"
 RUN curl -sL "https://deb.nodesource.com/setup_${NODE_VERSION}" | bash - \
@@ -27,7 +27,7 @@ RUN cd /doccano/app/server/static \
 RUN cd /doccano \
  && python app/manage.py collectstatic --noinput
 
-FROM python:${PYTHON_VERSION}-slim AS runtime
+FROM python:${PYTHON_VERSION}-slim-stretch AS runtime
 
 RUN useradd -ms /bin/sh doccano
 


### PR DESCRIPTION
Recently the base Python image was updated from Debian stretch to Debian buster. This breaks the CI since the node setup script fails to install npm on buster (sample broke build [1](https://travis-ci.org/CatalystCode/doccano/builds/559133008), [2](https://travis-ci.org/CatalystCode/doccano/builds/559109537)). Pinning the Python image to stretch fixes the issues and should prevent these sorts of regressions in the future (sample passed build [3](https://travis-ci.org/CatalystCode/doccano/builds/559165131)).