### PR TITLE
Added support to download annotated data in CoNLL format

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,9 @@ cd ..
 ```bash
 docker-compose pull
 ```
+**NOTE**: 
+To run any `docker` command on windows then please make sure "Docker Desktop" is installed and running.
+For error - "ERROR: for doccano_django_1  Cannot create container for service django: b'Drive has not been shared'", please follow this link - <https://github.com/docker/compose/issues/4854>
 
 ## Usage
 

--- a/app/api/tests/test_api.py
+++ b/app/api/tests/test_api.py
@@ -1017,7 +1017,7 @@ class TestDownloader(APITestCase):
     def test_cannot_download_conll_format_file(self):
         self.download_test_helper(url=self.labeling_url,
                                   format='conll',
-                                  expected_status=status.HTTP_400_BAD_REQUEST)
+                                  expected_status=status.HTTP_200_OK)
 
     def test_can_download_classification_csv(self):
         self.download_test_helper(url=self.classification_url,

--- a/app/api/views.py
+++ b/app/api/views.py
@@ -20,8 +20,8 @@ from .permissions import IsAdminUserAndWriteOnly, IsProjectUser, IsOwnAnnotation
 from .serializers import ProjectSerializer, LabelSerializer, DocumentSerializer, UserSerializer
 from .serializers import ProjectPolymorphicSerializer
 from .utils import CSVParser, JSONParser, PlainTextParser, CoNLLParser, iterable_to_io
-from .utils import JSONLRenderer
-from .utils import JSONPainter, CSVPainter
+from .utils import JSONLRenderer, CoNLLRenderer
+from .utils import JSONPainter, CSVPainter, CONLLPainter
 
 
 class Me(APIView):
@@ -292,7 +292,7 @@ class CloudUploadAPI(APIView):
 
 class TextDownloadAPI(APIView):
     permission_classes = (IsAuthenticated, IsProjectUser, IsAdminUser)
-    renderer_classes = (CSVRenderer, JSONLRenderer)
+    renderer_classes = (CSVRenderer, JSONLRenderer, CoNLLRenderer)
 
     def get(self, request, *args, **kwargs):
         format = request.query_params.get('q')
@@ -305,6 +305,9 @@ class TextDownloadAPI(APIView):
         if format == "json1":
             labels = project.labels.all()
             data = JSONPainter.paint_labels(documents, labels)
+        elif format == 'conll':
+            labels = project.labels.all()
+            data = CONLLPainter.paint_labels(documents, labels)
         else:
             data = painter.paint(documents)
         return Response(data)
@@ -314,5 +317,7 @@ class TextDownloadAPI(APIView):
             return CSVPainter()
         elif format == 'json' or format == "json1":
             return JSONPainter()
+        elif format == 'conll':
+            return CONLLPainter()
         else:
             raise ValidationError('format {} is invalid.'.format(format))

--- a/app/server/static/components/download_sequence_labeling.vue
+++ b/app/server/static/components/download_sequence_labeling.vue
@@ -22,6 +22,16 @@ block select-format-area
     )
     | JSON(Text-Labels)
 
+  label.radio
+    input(
+      type="radio"
+      name="format"
+      value="conll"
+      v-bind:checked="format == 'conll'"
+      v-model="format"
+    )
+    | CoNLL
+
 block example-format-area
   pre.code-block(v-show="format == 'json'")
     code.json
@@ -31,6 +41,11 @@ block example-format-area
   pre.code-block(v-show="format == 'json1'")
     code.json
       include ./examples/download_sequence_labeling.json1l
+      | ...
+
+  pre.code-block(v-show="format == 'conll'")
+    code.json
+      include ./examples/download_sequence_labeling.conll
       | ...
 </template>
 

--- a/app/server/static/components/examples/download_sequence_labeling.conll
+++ b/app/server/static/components/examples/download_sequence_labeling.conll
@@ -1,0 +1,12 @@
+EU	B-ORG
+rejects	O
+German	B-MISC
+call	O
+to	O
+boycott	O
+British	B-MISC
+lamb	O
+.	O
+
+Peter	B-PER
+Blackburn	I-PER

--- a/app/server/static/components/uploadMixin.js
+++ b/app/server/static/components/uploadMixin.js
@@ -104,6 +104,9 @@ export default {
       if (this.format === 'csv') {
         headers.Accept = 'text/csv; charset=utf-8';
         headers['Content-Type'] = 'text/csv; charset=utf-8';
+      } else if (this.format === 'conll') {
+        headers.Accept = 'text/plain';
+        headers['Content-Type'] = 'text/plain';
       } else {
         headers.Accept = 'application/json';
         headers['Content-Type'] = 'application/json';


### PR DESCRIPTION
This commit is regarding adding support to download annotated data in CoNLL format whose format can be tweaked a bit under configuration done in below python file:
\doccano\app\api\utils.py

DELIMITERS_FOR_CONLL_FORMAT = {
        "TOKENIZER_REGEX"               : r"[ ]",
        "TOKENIZER_DELIMITER_CHAR_COUNT": 1,
        "BETWEEN_WORD_AND_TAG"          : "   ",
        "BETWEEN_TOKENS"                : "\n",
        "BETWEEN_DOCUMENTS"             : "\n\n",
}

Please let me know for any review comments.