### PR TITLE
Enhancement/Extend integration tests to cover SQL Server database

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ python:
 env:
   - DATABASE=sqlite
   - DATABASE=postgres
+  - DATABASE=mssql
 
 services:
   - docker
@@ -16,6 +17,11 @@ before_install:
     if [[ "${DATABASE}" = "postgres" ]]; then
       docker run --rm --name=postgres --network=doccano -d -e POSTGRES_USER=user -e POSTGRES_PASSWORD=pass -e POSTGRES_DB=db postgres
       export DATABASE_URL="postgres://user:pass@postgres:5432/db?sslmode=disable"
+
+    elif [[ "${DATABASE}" = "mssql" ]]; then
+      docker run --rm --name=mssql --network=doccano -d -e ACCEPT_EULA=y -e SA_PASSWORD=sUp3rS3cr3t mcr.microsoft.com/mssql/server:2017-latest
+      docker exec -it mssql sh -c "while ! /opt/mssql-tools/bin/sqlcmd -U SA -P sUp3rS3cr3t -Q 'CREATE DATABASE db;'; do sleep 3; done"
+      export DATABASE_URL="mssql://SA:sUp3rS3cr3t@mssql:1433/db?sslmode=disable"
     fi
 
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,7 +31,7 @@ script:
   - docker build --target=builder --tag=doccano-test .
   - >
     if [[ "${DATABASE}" != "sqlite" ]]; then
-      docker run --network doccano -e DATABASE_URL="${DATABASE_URL}" -it doccano-test sh -c 'app/manage.py migrate && app/manage.py test api.tests server.tests'
+      docker run --network doccano -e DATABASE_URL="${DATABASE_URL}" -it doccano-test sh -c 'app/manage.py wait_for_db && app/manage.py migrate && app/manage.py test api.tests server.tests'
     fi
 
 before_deploy:

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,8 +6,8 @@ RUN curl -sL "https://deb.nodesource.com/setup_${NODE_VERSION}" | bash - \
  && apt-get install --no-install-recommends -y \
       nodejs=8.16.0-1nodesource1
 
-RUN apt-get install --no-install-recommends -y \
-      unixodbc-dev=2.3.4-1
+COPY tools/install-mssql.sh /doccano/tools/install-mssql.sh
+RUN /doccano/tools/install-mssql.sh --dev
 
 COPY app/server/static/package*.json /doccano/app/server/static/
 RUN cd /doccano/app/server/static \
@@ -33,19 +33,8 @@ RUN cd /doccano \
 
 FROM python:${PYTHON_VERSION}-slim-stretch AS runtime
 
-RUN apt-get update \
- && apt-get install --no-install-recommends -y \
-      curl=7.52.1-5+deb9u9 \
-      gnupg=2.1.18-8~deb9u4 \
-      apt-transport-https=1.4.9 \
- && curl -fsS https://packages.microsoft.com/keys/microsoft.asc | apt-key add - \
- && curl -fsS https://packages.microsoft.com/config/debian/9/prod.list > /etc/apt/sources.list.d/mssql.list \
- && apt-get update \
- && ACCEPT_EULA=Y apt-get install --no-install-recommends -y \
-      msodbcsql17=17.3.1.1-1 \
-      mssql-tools=17.3.0.1-1 \
- && apt-get remove -y curl gnupg apt-transport-https \
- && rm -rf /var/lib/apt/lists/*
+COPY --from=builder /doccano/tools/install-mssql.sh /doccano/tools/install-mssql.sh
+RUN /doccano/tools/install-mssql.sh
 
 RUN useradd -ms /bin/sh doccano
 

--- a/tools/install-mssql.sh
+++ b/tools/install-mssql.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+
+# parse arguments
+mode="prod"
+for opt in "$@"; do
+  case "${opt}" in
+    --dev) mode="dev" ;;
+  esac
+done
+
+set -eo pipefail
+
+# install build dependencies
+apt-get update
+apt-get install --no-install-recommends -y \
+      curl=7.52.1-5+deb9u9 \
+      gnupg=2.1.18-8~deb9u4 \
+      apt-transport-https=1.4.9
+
+# install dependency to compile django-pyodbc-azure
+if [[ "${mode}" = "dev" ]]; then
+  apt-get install --no-install-recommends -y \
+      unixodbc-dev=2.3.4-1
+fi
+
+# add mssql repo
+curl -fsS https://packages.microsoft.com/keys/microsoft.asc | apt-key add -
+curl -fsS https://packages.microsoft.com/config/debian/9/prod.list > /etc/apt/sources.list.d/mssql.list
+apt-get update
+
+# install mssql
+ACCEPT_EULA=Y apt-get install --no-install-recommends -y \
+      msodbcsql17=17.3.1.1-1 \
+      mssql-tools=17.3.0.1-1
+
+# remove build dependencies and artifacts
+apt-get remove -y \
+      curl gnupg apt-transport-https
+rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
This pull request ensures that Doccano's support for SQL Server (introduced in https://github.com/chakki-works/doccano/pull/255) is covered in the database backend test infrastructure (introduced in in https://github.com/chakki-works/doccano/pull/278).

Given that the database backend tests run in the builder stage of the Dockerfile, this pull request also moves the SQL server system dependency setup into a script so that the code to install the dependencies doesn't have to be copy/pasted between the runtime and builder stages.