### PR TITLE
Enhancement/Enable token authorization for API calls

### DIFF
--- a/app/api/urls.py
+++ b/app/api/urls.py
@@ -1,4 +1,5 @@
 from django.urls import path
+from rest_framework.authtoken.views import obtain_auth_token
 from rest_framework.urlpatterns import format_suffix_patterns
 
 from .views import Me, Features
@@ -11,6 +12,7 @@ from .views import StatisticsAPI
 
 
 urlpatterns = [
+    path('auth-token', obtain_auth_token),
     path('me', Me.as_view(), name='me'),
     path('features', Features.as_view(), name='features'),
     path('cloud-upload', CloudUploadAPI.as_view(), name='cloud_uploader'),

--- a/app/app/settings.py
+++ b/app/app/settings.py
@@ -55,6 +55,7 @@ INSTALLED_APPS = [
     'api.apps.ApiConfig',
     'widget_tweaks',
     'rest_framework',
+    'rest_framework.authtoken',
     'django_filters',
     'social_django',
     'polymorphic',
@@ -210,6 +211,10 @@ REST_FRAMEWORK = {
         'rest_framework.permissions.DjangoModelPermissionsOrAnonReadOnly',
         'rest_framework.permissions.IsAuthenticated',
     ],
+    'DEFAULT_AUTHENTICATION_CLASSES': (
+        'rest_framework.authentication.SessionAuthentication',
+        'rest_framework.authentication.TokenAuthentication',
+    ),
     'DEFAULT_PAGINATION_CLASS': 'rest_framework.pagination.LimitOffsetPagination',
     'PAGE_SIZE': 5,
     'DEFAULT_FILTER_BACKENDS': ('django_filters.rest_framework.DjangoFilterBackend',),


### PR DESCRIPTION
As discussed in https://github.com/chakki-works/doccano/issues/299, there is desire to interact with Doccano via the API since this enables integrating Doccano with others systems, e.g. fetch data from system A, push it into Doccano, and later sync the labels to system B.

In order to facilitate usage of Doccano via the API, this pull request adds token authentication to the API:

```sh
# fetch an auth token once for non-interactive usage of the API
curl 'http://localhost:8000/v1/auth-token' -d '{"username": "user", "password": "pass"}' -H 'Content-Type: application/json'

# at a later point, can use the auth token to interact with the API
curl 'http://localhost:8000/v1/me' -H 'Authorization: Token xxxxxxxxx'
```