### PR TITLE
Enhancement/long document annotation improvements

### DIFF
--- a/app/app/settings.py
+++ b/app/app/settings.py
@@ -211,7 +211,7 @@ REST_FRAMEWORK = {
         'rest_framework.permissions.IsAuthenticated',
     ],
     'DEFAULT_PAGINATION_CLASS': 'rest_framework.pagination.LimitOffsetPagination',
-    'PAGE_SIZE': 5,
+    'PAGE_SIZE': env.int('DOCCANO_PAGE_SIZE', default=5),
     'DEFAULT_FILTER_BACKENDS': ('django_filters.rest_framework.DjangoFilterBackend',),
     'SEARCH_PARAM': 'q',
     'DEFAULT_RENDERER_CLASSES': (

--- a/app/server/static/assets/css/annotation.css
+++ b/app/server/static/assets/css/annotation.css
@@ -12,6 +12,17 @@ body {
   border-right: 1px solid #DEDEDE;
 }
 
+.scrollable {
+  max-height: 60vh;
+  overflow-y: auto;
+}
+
+.sidebar-scrollable {
+  max-height: 100vh;
+  overflow-y: auto;
+  overflow-x: hidden;
+}
+
 .messages {
   display: block;
   background-color: #fff;

--- a/app/server/static/components/annotation.pug
+++ b/app/server/static/components/annotation.pug
@@ -55,7 +55,7 @@ div.columns(v-cloak="")
       div.main.pt0.pb0.pr20.pl20
         span About {{ count }} results
 
-      div.main
+      div.main.sidebar-scrollable
         a.item(
           v-for="(doc, index) in docs"
           v-bind:class="{ active: index == pageNumber }"

--- a/app/server/static/components/annotation.pug
+++ b/app/server/static/components/annotation.pug
@@ -53,7 +53,7 @@ div.columns(v-cloak="")
                       | Completed
 
       div.main.pt0.pb0.pr20.pl20
-        span About {{ count }} results
+        span About {{ count }} results (page {{ paginationPage }} of {{ paginationPages }})
 
       div.main.sidebar-scrollable
         a.item(
@@ -141,22 +141,41 @@ div.columns(v-cloak="")
         preview(v-bind:url="documentMetadata.documentSourceUrl")
 
     div.level.mt30
-      a.button.level-left(
-        v-shortkey="{ prev1: ['ctrl', 'p'], prev2: ['arrowup'], prev3: ['arrowleft'] }"
-        v-on:click="prevPage"
-        v-on:shortkey="prevPage"
-      )
-        span.icon
-          i.fas.fa-chevron-left
-        span Prev
+      div.level-left
+        div.buttons
+          a.button(
+            v-shortkey="{ prev1: ['shift', 'ctrl', 'p'], prev2: ['shift', 'arrowup'], prev3: ['shift', 'arrowleft'] }"
+            v-on:click="prevPagination"
+            v-on:shortkey="prevPagination"
+          )
+            span.icon.tooltip(data-tooltip="Previous page")
+              i.fas.fa-arrow-left
 
-      span.button.level-center.is-static {{ offset + pageNumber + 1 }} / {{ count }}
+          a.button(
+            v-shortkey="{ prev1: ['ctrl', 'p'], prev2: ['arrowup'], prev3: ['arrowleft'] }"
+            v-on:click="prevPage"
+            v-on:shortkey="prevPage"
+          )
+            span.icon.tooltip(data-tooltip="Previous document")
+              i.fas.fa-chevron-left
 
-      a.button.level-right(
-        v-shortkey="{ next1: ['ctrl', 'n'], next2: ['arrowdown'], next3: ['arrowright'] }"
-        v-on:click="nextPage"
-        v-on:shortkey="nextPage"
-      )
-        span Next
-        span.icon
-          i.fas.fa-chevron-right
+      div.level-center
+        span.button.is-static {{ offset + pageNumber + 1 }} / {{ count }}
+
+      div.level-right
+        div.buttons
+          a.button(
+            v-shortkey="{ next1: ['ctrl', 'n'], next2: ['arrowdown'], next3: ['arrowright'] }"
+            v-on:click="nextPage"
+            v-on:shortkey="nextPage"
+          )
+            span.icon.tooltip(data-tooltip="Next document")
+              i.fas.fa-chevron-right
+
+          a.button(
+            v-shortkey="{ next1: ['shift', 'ctrl', 'n'], next2: ['shift', 'arrowdown'], next3: ['shift', 'arrowright'] }"
+            v-on:click="nextPagination"
+            v-on:shortkey="nextPagination"
+          )
+            span.icon.tooltip(data-tooltip="Next page")
+              i.fas.fa-arrow-right

--- a/app/server/static/components/annotationMixin.js
+++ b/app/server/static/components/annotationMixin.js
@@ -60,6 +60,13 @@ export default {
   },
 
   methods: {
+    resetScrollbar() {
+      const textbox = this.$refs.textbox;
+      if (textbox) {
+        textbox.scrollTop = 0;
+      }
+    },
+
     async nextPage() {
       this.pageNumber += 1;
       if (this.pageNumber === this.docs.length) {
@@ -70,6 +77,8 @@ export default {
         } else {
           this.pageNumber = this.docs.length - 1;
         }
+      } else {
+        this.resetScrollbar();
       }
     },
 
@@ -83,6 +92,8 @@ export default {
         } else {
           this.pageNumber = 0;
         }
+      } else {
+        this.resetScrollbar();
       }
     },
 

--- a/app/server/static/components/document_classification.vue
+++ b/app/server/static/components/document_classification.vue
@@ -33,8 +33,8 @@ block annotation-area
               button.delete.is-small(v-on:click="removeLabel(annotation)")
 
       hr
-      div.content(v-if="docs[pageNumber]")
-        span.text {{ docs[pageNumber].text }}
+      div.content
+        div.text.scrollable(ref="textbox", v-if="docs[pageNumber]") {{ docs[pageNumber].text }}
 </template>
 
 <style scoped>

--- a/app/server/static/components/sequence_labeling.vue
+++ b/app/server/static/components/sequence_labeling.vue
@@ -21,7 +21,7 @@ block annotation-area
                 kbd {{ shortcutKey(label) | simpleShortcut }}
 
     div.card-content
-      div.content(v-if="docs[pageNumber] && annotations[pageNumber]")
+      div.content.scrollable(v-if="docs[pageNumber] && annotations[pageNumber]", ref="textbox")
         annotator(
           v-bind:labels="labels"
           v-bind:entity-positions="annotations[pageNumber]"


### PR DESCRIPTION
This PR adds some functionality to help with annotation of longer documents. 
- Fixes header so that labels can be seen when scrolling down document.
- Fixes sidebar so that the document pane scrolls freely. 
- Introduces pagination button to skip forward/backwards for an entire page of documents.