### PR TITLE
change the download file format

### DIFF
--- a/app/server/static/components/uploadMixin.js
+++ b/app/server/static/components/uploadMixin.js
@@ -120,10 +120,14 @@ export default {
         const url = window.URL.createObjectURL(new Blob([response.data]));
         const link = document.createElement('a');
         link.href = url;
-        link.setAttribute('download', 'file.' + this.format); // or any other extension
-        document.body.appendChild(link);
-        this.isLoading = false;
-        link.click();
+        var id = window.location.pathname.split('/')[2];
+        defaultHttpClient.get(`/v1/projects/${id}`).then((response) => {
+          this.name = response.data.name;
+          link.setAttribute('download', `${this.name}.` + this.format); // or any other extension
+          document.body.appendChild(link);
+          this.isLoading = false;
+          link.click();
+        });
       }).catch((error) => {
         this.isLoading = false;
         this.handleError(error);


### PR DESCRIPTION
Export data as a {project_name}.{file_format} format

It is difficult to identify where the exported data came from if an admin manages a lot of project.

The name of downloaded data is currently ('file.' + this.format) but this pull request exports data as below

Project name : test_project

![image](https://user-images.githubusercontent.com/41753422/63004946-83702180-beb6-11e9-9338-d7421cf7b8d3.png)

Exported file name : test_project.json

![image](https://user-images.githubusercontent.com/41753422/63004985-98e54b80-beb6-11e9-9c3d-683ff12e3384.png)


The code should be improved because the code is to show my idea roughly.