### PR TITLE
Bugfix/Fix filename determination with URL querystring

### DIFF
--- a/app/server/static/components/preview.vue
+++ b/app/server/static/components/preview.vue
@@ -24,7 +24,7 @@ export default {
 
   computed: {
     fileExtension() {
-      const filename = this.url.split('/').pop();
+      const filename = new URL(this.url).pathname.split('/').pop();
       const extension = filename.match(/[^#?]+/)[0].split('.').pop();
       return extension.toLowerCase();
     },


### PR DESCRIPTION
The preview Vue component contains logic to determine a file's type given an access URL. This pull request fixes that logic for the case where a URL contains a querystring such as `http://some/file.pdf?q=1`.