### PR TITLE
Bugfix/Fix label creation process

### DIFF
--- a/app/api/serializers.py
+++ b/app/api/serializers.py
@@ -41,10 +41,9 @@ class LabelSerializer(serializers.ModelSerializer):
             pass  # unit tests don't always have the correct context set up
         else:
             if Label.objects.filter(suffix_key=suffix_key,
-                                    prefix_key__isnull=True,
+                                    prefix_key=prefix_key,
                                     project=project_id).exists():
                 raise ValidationError('Duplicate key.')
-
         return super().validate(attrs)
 
     class Meta:

--- a/app/api/tests/test_api.py
+++ b/app/api/tests/test_api.py
@@ -209,6 +209,26 @@ class TestLabelListAPI(APITestCase):
         response = self.client.post(self.other_url, format='json', data=label)
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
 
+    def test_can_create_same_suffix_with_different_prefix(self):
+        self.client.login(username=self.super_user_name,
+                          password=self.super_user_pass)
+        label = {'text': 'Person', 'prefix_key': None, 'suffix_key': 'p'}
+        response = self.client.post(self.url, format='json', data=label)
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        label = {'text': 'Percentage', 'prefix_key': 'ctrl', 'suffix_key': 'p'}
+        response = self.client.post(self.url, format='json', data=label)
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+
+    def test_cannot_create_same_shortcut_key(self):
+        self.client.login(username=self.super_user_name,
+                          password=self.super_user_pass)
+        label = {'text': 'Person', 'prefix_key': None, 'suffix_key': 'p'}
+        response = self.client.post(self.url, format='json', data=label)
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        label = {'text': 'Percentage', 'prefix_key': None, 'suffix_key': 'p'}
+        response = self.client.post(self.url, format='json', data=label)
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+
     def test_disallows_project_member_to_create_label(self):
         self.client.login(username=self.project_member_name,
                           password=self.project_member_pass)

--- a/app/server/static/components/label.vue
+++ b/app/server/static/components/label.vue
@@ -252,6 +252,9 @@ export default {
     },
 
     addLabel() {
+      if (this.newLabel.prefix_key === '') {
+        this.newLabel.prefix_key = null;
+      }
       HTTP.post('labels', this.newLabel)
         .then((response) => {
           this.cancelCreate();


### PR DESCRIPTION
There is a bug in a label creation process. The following is a reproducible case:

* First, setting a `suffix_key=p` and create a label. This will be successful.
* Then, setting a `suffix_key=p` and `prefix_key=ctrl` and change `prefix_key=""`. This will be a failure.

The reason:

The default value of prefix key is null, but if we set ctrl, shift or ctrl+shift a prefix key and change it to "", the value is changed from null to empty string. So both of the shortcut keys is a different one. That's why we can create the "same" shortcut key.


