### PR TITLE
Bugfix/Make usage of Python 3 binary explicit

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -55,7 +55,7 @@ wheels/
 MANIFEST
 
 # PyInstaller
-#  Usually these files are written by a python script from a template
+#  Usually these files are written by a Python script from a template
 #  before PyInstaller builds the exe, so as to inject date/other infos into it.
 *.manifest
 *.spec

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,7 @@ before_install:
     fi
 
 install:
-    - pip install mkdocs mkdocs-material
+    - pip3 install mkdocs mkdocs-material
 
 script:
   - docker build --target=builder --tag=doccano-test .

--- a/Dockerfile
+++ b/Dockerfile
@@ -29,7 +29,7 @@ RUN cd /doccano/app/server/static \
  && rm -rf components pages node_modules .*rc package*.json webpack.config.js
 
 RUN cd /doccano \
- && python app/manage.py collectstatic --noinput
+ && python3 app/manage.py collectstatic --noinput
 
 FROM python:${PYTHON_VERSION}-slim-stretch AS runtime
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,8 +14,8 @@ RUN cd /doccano/app/server/static \
  && npm ci
 
 COPY requirements.txt /
-RUN pip install -r /requirements.txt \
- && pip wheel -r /requirements.txt -w /deps
+RUN pip3 install -r /requirements.txt \
+ && pip3 wheel -r /requirements.txt -w /deps
 
 COPY . /doccano
 
@@ -39,7 +39,7 @@ RUN /doccano/tools/install-mssql.sh
 RUN useradd -ms /bin/sh doccano
 
 COPY --from=builder /deps /deps
-RUN pip install --no-cache-dir /deps/*.whl
+RUN pip3 install --no-cache-dir /deps/*.whl
 
 COPY --from=cleaner --chown=doccano:doccano /doccano /doccano
 

--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ First we need to install the dependencies. Run the following commands:
 
 ```bash
 sudo apt-get install libpq-dev
-pip install -r requirements.txt
+pip3 install -r requirements.txt
 cd app
 ```
 

--- a/README.md
+++ b/README.md
@@ -141,31 +141,31 @@ docker run -d --rm --name doccano \
 Before running, we need to make migration. Run the following command:
 
 ```bash
-python manage.py migrate
+python3 manage.py migrate
 ```
 
 Next we need to create a user who can login to the admin site. Run the following command:
 
 ```bash
-python manage.py create_admin --noinput --username "admin" --email "admin@example.com" --password "password"
+python3 manage.py create_admin --noinput --username "admin" --email "admin@example.com" --password "password"
 ```
 
 Developers can also validate that the project works as expected by running the tests:
 
 ```bash
-python manage.py test server.tests
+python3 manage.py test server.tests
 ```
 
 Finally, to start the server, run the following command:
 
 ```bash
-python manage.py runserver
+python3 manage.py runserver
 ```
 
 Optionally, you can change the bind ip and port using the command
 
 ```bash
-python manage.py runserver <ip>:<port>
+python3 manage.py runserver <ip>:<port>
 ```
 
 #### Option 3: Running the development Docker-Compose stack

--- a/docs/advanced/oauth2_settings.md
+++ b/docs/advanced/oauth2_settings.md
@@ -28,7 +28,7 @@ export OAUTH_GITHUB_SECRET=YOUR_CLIENT_SECRET
 ## Run server
 
 ```bash
-python manage.py runserver
+python3 manage.py runserver
 ```
 
 Go to login page:

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -28,11 +28,11 @@ Following list is ordered by from easy to hard. If you are not familiar with Pyt
    * Build frontend library: `npm install`
    * Build frontend source code: `npm run build`
    * Back to server directory: `cd ../`
-   * Initialize doccano: `python manage.py migrate`
-   * Create user: `python manage.py createsuperuser`
-   * Run doccano: `python manage.py runserver`
+   * Initialize doccano: `python3 manage.py migrate`
+   * Create user: `python3 manage.py createsuperuser`
+   * Run doccano: `python3 manage.py runserver`
    * Stop doccano: Ctrl+C
-   * Re-Launch doccano: `python manage.py runserver` (Confirm you are at `app/server` directory and environment is active).
+   * Re-Launch doccano: `python3 manage.py runserver` (Confirm you are at `app/server` directory and environment is active).
 
 ## I can't upload my data.
 

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -23,7 +23,7 @@ Following list is ordered by from easy to hard. If you are not familiar with Pyt
    * Move to doccano directory: `cd doccano`
    * Create environment for doccano: `virtualenv venv`
    * Activate environment: `source venv/bin/activate`
-   * Install required packages: `pip install -r requirements.txt`
+   * Install required packages: `pip3 install -r requirements.txt`
    * Move server directory: `cd app/server`
    * Build frontend library: `npm install`
    * Build frontend source code: `npm run build`

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -28,7 +28,7 @@ docker-compose pull
 First we need to install the dependencies. Run the following commands:
 
 ```bash
-pip install -r requirements.txt
+pip3 install -r requirements.txt
 cd app
 ```
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -80,23 +80,23 @@ Now, open a Web browser and go to <http://127.0.0.1:8000/login/>. You should see
 Before running, we need to make migration. Run the following command:
 
 ```bash
-python manage.py migrate
+python3 manage.py migrate
 ```
 
 Next we need to create a user who can login to the admin site. Run the following command:
 
 ```bash
-python manage.py create_admin --noinput --username "admin" --email "admin@example.com" --password "password"
+python3 manage.py create_admin --noinput --username "admin" --email "admin@example.com" --password "password"
 ```
 
 Developers can also validate that the project works as expected by running the tests:
 
 ```bash
-python manage.py test server.tests
+python3 manage.py test server.tests
 ```
 
 Finally, to start the server, run the following command:
 
 ```bash
-python manage.py runserver
+python3 manage.py runserver
 ```

--- a/tools/ci.sh
+++ b/tools/ci.sh
@@ -3,7 +3,7 @@
 set -o errexit
 
 flake8
-python app/manage.py migrate
+python3 app/manage.py migrate
 coverage run --source=app app/manage.py test server.tests api.tests authentification.tests
 coverage report
 

--- a/tools/create-admin.sh
+++ b/tools/create-admin.sh
@@ -4,6 +4,6 @@ if [[ "$#" -ne 3 ]]; then echo "Usage: $0 <username> <email> <password>" >&2; ex
 
 set -o errexit
 
-python app/manage.py wait_for_db
-python app/manage.py migrate
-python app/manage.py create_admin --noinput --username="$1" --email="$2" --password="$3"
+python3 app/manage.py wait_for_db
+python3 app/manage.py migrate
+python3 app/manage.py create_admin --noinput --username="$1" --email="$2" --password="$3"

--- a/tools/dev-django.sh
+++ b/tools/dev-django.sh
@@ -10,11 +10,11 @@ if [[ ! -f "${venv}/bin/python" ]]; then
   echo "Creating virtualenv"
   mkdir -p "${venv}"
   python3 -m venv "${venv}"
-  "${venv}/bin/pip" install --upgrade pip setuptools
+  "${venv}/bin/pip3" install --upgrade pip setuptools
 fi
 
 echo "Installing dependencies"
-"${venv}/bin/pip" install -r "${root}/requirements.txt"
+"${venv}/bin/pip3" install -r "${root}/requirements.txt"
 
 echo "Initializing database"
 "${venv}/bin/python" "${app}/manage.py" wait_for_db

--- a/tools/heroku.sh
+++ b/tools/heroku.sh
@@ -3,5 +3,5 @@
 set -o errexit
 
 if [ -n "$ADMIN_USER_NAME" ]; then
-    python app/manage.py create_admin --noinput --username="$ADMIN_USER_NAME" --email="$ADMIN_CONTACT_EMAIL" --password="$ADMIN_PASSWORD"
+    python3 app/manage.py create_admin --noinput --username="$ADMIN_USER_NAME" --email="$ADMIN_CONTACT_EMAIL" --password="$ADMIN_PASSWORD"
 fi

--- a/tools/run.sh
+++ b/tools/run.sh
@@ -2,13 +2,13 @@
 
 set -o errexit
 
-if [[ ! -d "app/staticfiles" ]]; then python app/manage.py collectstatic --noinput; fi
+if [[ ! -d "app/staticfiles" ]]; then python3 app/manage.py collectstatic --noinput; fi
 
-python app/manage.py wait_for_db
-python app/manage.py migrate
+python3 app/manage.py wait_for_db
+python3 app/manage.py migrate
 
 if [[ -n "${ADMIN_USERNAME}" ]] && [[ -n "${ADMIN_EMAIL}" ]] && [[ -n "${ADMIN_PASSWORD}" ]]; then
-  python app/manage.py create_admin --noinput --username="${ADMIN_USERNAME}" --email="${ADMIN_EMAIL}" --password="${ADMIN_PASSWORD}"
+  python3 app/manage.py create_admin --noinput --username="${ADMIN_USERNAME}" --email="${ADMIN_EMAIL}" --password="${ADMIN_PASSWORD}"
 fi
 
 gunicorn --bind="0.0.0.0:${PORT:-8000}" --workers="${WORKERS:-1}" --pythonpath=app app.wsgi --timeout 300


### PR DESCRIPTION
I recently tried to run doccano on a CentOS 7 system. CentOS 7's `python` binary links to python2 by default which means that even if python3 is installed via yum, all the scripts and tooling in doccano break since they reference the default `python` binary.

Making it explicit that we're requiring python3 to run the scripts fixes this class of errors and also acts as additional documentation for future developers to make it clear that doccano does not work on python2.