### PR TITLE
Enhancement/Add settings required for SSL

### DIFF
--- a/app/app/settings.py
+++ b/app/app/settings.py
@@ -266,6 +266,9 @@ if DATABASES['default'].get('ENGINE') == 'sql_server.pyodbc':
 
 # Honor the 'X-Forwarded-Proto' header for request.is_secure()
 SECURE_PROXY_SSL_HEADER = ('HTTP_X_FORWARDED_PROTO', 'https')
+SESSION_COOKIE_SECURE = env.bool('SESSION_COOKIE_SECURE', False)
+CSRF_COOKIE_SECURE = env.bool('CSRF_COOKIE_SECURE', False)
+CSRF_TRUSTED_ORIGINS = env.list('CSRF_TRUSTED_ORIGINS', [])
 
 # Allow all host headers
 # ALLOWED_HOSTS = ['*']


### PR DESCRIPTION
Many of doccano's settings are currently configurable via the environment as per the [12-factor methodology](https://12factor.net). This pull request extends the configuration to also include settings required to run doccano successfully behind an SSL terminating proxy. The change is fully backwards compatible since by default the new environment variables are disabled.

Example environment configuration to enable custom SSL:

```sh
export SESSION_COOKIE_SECURE="True"
export CSRF_COOKIE_SECURE="True"
export CSRF_TRUSTED_ORIGINS="some.domain.com"
```