### PR TITLE
Fixes #309 read settings properly

### DIFF
--- a/app/authentification/tests/test_template.py
+++ b/app/authentification/tests/test_template.py
@@ -1,7 +1,7 @@
 from django.test import SimpleTestCase, TestCase, RequestFactory, override_settings
 from django.http import HttpRequest
 from ..views import SignupView
-from app import settings
+from django.conf import settings
 from api.tests.test_config import setenv
 
 @override_settings(STATICFILES_STORAGE='django.contrib.staticfiles.storage.StaticFilesStorage')

--- a/app/authentification/views.py
+++ b/app/authentification/views.py
@@ -9,7 +9,7 @@ from django.core.mail import EmailMessage
 from django.views.generic import TemplateView
 from django.shortcuts import redirect
 
-from app import settings
+from django.conf import settings
 
 
 class SignupView(TemplateView):


### PR DESCRIPTION
Email settings from custom settings module, configured via `DJANGO_SETTINGS_MODULE`, were ignored.