### PR TITLE
Bugfix/Only attempt deployments on upstream repository

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -41,11 +41,13 @@ deploy:
   - provider: script
     script: tools/cd.sh travis-${TRAVIS_BUILD_NUMBER}
     on:
+      repo: chakki-works/doccano
       branch: master
 
   - provider: script
     script: tools/cd.sh ${TRAVIS_TAG}
     on:
+      repo: chakki-works/doccano
       tags: true
 
   - provider: pages
@@ -53,4 +55,5 @@ deploy:
     github_token: $GITHUB_TOKEN
     local_dir: site
     on:
+        repo: chakki-works/doccano
         branch: master


### PR DESCRIPTION
The current Travis configuration attempts continuous delivery/deployment on every master build. This includes forked repositories, but the builds on forks will likely error due to missing credentials (see [sample fork build error](https://travis-ci.org/CatalystCode/doccano/jobs/574306205)). To prevent confusion, this change restricts the Travis configuration to only attempt deployments for builds running on the chakki-works repository (see [sample fork build success](https://travis-ci.org/CatalystCode/doccano/jobs/580750283)).