### PR TITLE
Add linter for Dockerfile

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -5,6 +5,7 @@
 !.coveragerc
 !.flake8
 !requirements.txt
+!Dockerfile
 
 app/**/bundle/
 app/**/node_modules/


### PR DESCRIPTION
This PR adds Hadolint, a Haskell Dockerfile linter, to doccano's Dockerfile which currently has a few Hadolint errors. 

1. Installs Hadolint v1.17.1
2. Runs Hadolint on /Dockerfile
3. Ignores two errors with inline `# hadolint ignore=[Error Code]` 
         a. Ignore `Pin versions in apt-get install` where pinning a version on line 8 could cause build 
                  errors if the upstream node version changed.
         b. Ignore `Pin versions in pip` due to a false positive on line 53 where installing wheels is 
                  already at a specific version.
       
As a result, upon building the Dockerfile there should be no Hadolint errors.
 
Collaboration with @c-w 
