### PR TITLE
[discussion] GCP Run - "Free" deployment solution for small teams

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ Doccano can be deployed to AWS ([Cloudformation](https://docs.aws.amazon.com/AWS
 
 If you have a very small team, Doccano can also be deployed to GCP ([Cloud Run](https://cloud.google.com/run)) by clicking on the button below:
 
-https://console.cloud.google.com/cloudshell/editor?shellonly=true&cloudshell_image=gcr.io/cloudrun/doccano&cloudshell_git_repo=https://github.com/chakki-works/doccano.git
+[![GCP Cloud Run PNG Button](https://storage.googleapis.com/gweb-cloudblog-publish/images/run_on_google_cloud.max-300x300.png)](https://console.cloud.google.com/cloudshell/editor?shellonly=true&cloudshell_image=gcr.io/cloudrun/doccano&cloudshell_git_repo=https://github.com/chakki-works/doccano.git)
 
 > Note: Although this is a very cheap option, it is only suitable for very small teams (up to 80 concurrent requests). Read more on [Cloud Run docs](https://cloud.google.com/run/docs/concepts).
 

--- a/README.md
+++ b/README.md
@@ -58,6 +58,14 @@ Doccano can be deployed to AWS ([Cloudformation](https://docs.aws.amazon.com/AWS
 
 > Notice: (1) EC2 KeyPair cannot be created automatically, so make sure you have an existing EC2 KeyPair in one region. Or [create one yourself](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-key-pairs.html#having-ec2-create-your-key-pair). (2) If you want to access doccano via HTTPS in AWS, here is an [instruction](https://github.com/chakki-works/doccano/wiki/HTTPS-setting-for-doccano-in-AWS).
 
+### GCP
+
+If you have a very small team, Doccano can also be deployed to GCP ([Cloud Run](https://cloud.google.com/run)) by clicking on the button below:
+
+https://console.cloud.google.com/cloudshell/editor?shellonly=true&cloudshell_image=gcr.io/cloudrun/doccano&cloudshell_git_repo=https://github.com/chakki-works/doccano.git
+
+> Note: Although this is a very cheap option, it is only suitable for very small teams (up to 80 concurrent requests). Read more on [Cloud Run docs](https://cloud.google.com/run/docs/concepts).
+
 ## Features
 
 -   Collaborative annotation

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -1,0 +1,7 @@
+steps:
+- name: 'gcr.io/cloud-builders/docker'
+  args: ['build', '--tag=gcr.io/${PROJECT_ID}/almeta-doccano:${BRANCH_NAME}', '.']
+- name: 'gcr.io/cloud-builders/docker'
+  args: ["push", "gcr.io/${PROJECT_ID}/almeta-doccano:${BRANCH_NAME}"]
+- name: 'gcr.io/cloud-builders/gcloud'
+  args: ['beta', 'run', 'deploy', 'almeta-doccano', '--image', 'gcr.io/${PROJECT_ID}/almeta-doccano:${BRANCH_NAME}', '--region', 'us-central1', '--memory', '2G', '--platform', 'managed', '--allow-unauthenticated']


### PR DESCRIPTION
We were looking for an annotation tool and decided to go with yours, Nice work btw!

Given the following aspects:
- We are a very small team (<10 people)
- Cost should be as low as possible
- We annotate rather small datasets

We decided to go with GCP Run as a deployment solution, and it worked rather smoothly (thanks for having a Dockerfile ready)!  
Now, we are practically good to go, and our endpoint is up and running, but we were wondering if you think other people would be interested, given the aspects we just mentioned.

GCP Cloud Run is designed for stateless servers:
- Has a max RAM of 2GB
- Hard disk is not persistent among different deployments (i.e. once you deploy a new version, you will lose all data you have).

To do:
- [ ] Upload a Docker image of the latest doccano/master
- [ ] Update "Deploy to Cloud Run link"

If you want to test `cloudbuild.yaml` link this repo to Cloud Build and watch the magic! \^\^

*Do not worry about uploading and hosting the Docker image, we will easily and happily do that for free.*