### PR TITLE
Enhancement/Improve annotation creation performance

### DIFF
--- a/app/api/tests/test_api.py
+++ b/app/api/tests/test_api.py
@@ -1331,6 +1331,12 @@ class TestStatisticsAPI(APITestCase):
         self.assertIn('user', response.data)
         self.assertIsInstance(response.data['user'], dict)
 
+    def test_returns_partial_response(self):
+        self.client.login(username=self.super_user_name,
+                          password=self.super_user_pass)
+        response = self.client.get(f'{self.url}?include=user', format='json')
+        self.assertEqual(list(response.data.keys()), ['user'])
+
 
 class TestUserAPI(APITestCase):
 

--- a/app/api/views.py
+++ b/app/api/views.py
@@ -68,12 +68,22 @@ class StatisticsAPI(APIView):
 
     def get(self, request, *args, **kwargs):
         p = get_object_or_404(Project, pk=self.kwargs['project_id'])
-        label_count, user_count = self.label_per_data(p)
-        progress = self.progress(project=p)
-        response = dict()
-        response['label'] = label_count
-        response['user'] = user_count
-        response.update(progress)
+
+        include = set(request.GET.getlist('include'))
+        response = {}
+
+        if not include or 'label' in include or 'user' in include:
+            label_count, user_count = self.label_per_data(p)
+            response['label'] = label_count
+            response['user'] = user_count
+
+        if not include or 'total' in include or 'remaining' in include:
+            progress = self.progress(project=p)
+            response.update(progress)
+
+        if include:
+            response = {key: value for (key, value) in response.items() if key in include}
+
         return Response(response)
 
     def progress(self, project):

--- a/app/api/views.py
+++ b/app/api/views.py
@@ -187,8 +187,7 @@ class AnnotationList(generics.ListCreateAPIView):
         return super().create(request, args, kwargs)
 
     def perform_create(self, serializer):
-        doc = get_object_or_404(Document, pk=self.kwargs['doc_id'])
-        serializer.save(document=doc, user=self.request.user)
+        serializer.save(document_id=self.kwargs['doc_id'], user=self.request.user)
 
 
 class AnnotationDetail(generics.RetrieveUpdateDestroyAPIView):

--- a/app/server/static/components/annotationMixin.js
+++ b/app/server/static/components/annotationMixin.js
@@ -236,7 +236,7 @@ export default {
 
     annotations() {
       // fetch progress info.
-      HTTP.get('statistics').then((response) => {
+      HTTP.get('statistics?include=total&include=remaining').then((response) => {
         this.total = response.data.total;
         this.remaining = response.data.remaining;
       });


### PR DESCRIPTION
I noticed slowdowns in the annotation workflow with large documents, similar to the what has been described in https://github.com/chakki-works/doccano/issues/144.

The slowdowns seem to be linked to the performance of two requests:
- `GET /v1/projects/<project_id>/statistics`
- `POST /v1/projects/<project_id>/docs/<doc_id>/annotations`

This pull request improves the performance of the annotation creation workflow via two main optimizations:

- Avoid computing the label and user keys in the statistics response after a new annotation has been created (these properties get used on the stats page, not the annotations page). This saves a database aggregation query.

- Avoid pulling back the full document from the database on annotation creation (the annotation object only has a link to the document so we can use the document id to create the annotation and don't need to hydrate a full document object reference). This saves a database read that may potentially be expensive if the document is large as we may be pulling back thousands of lines of text from the database into the Django server.
