### PR TITLE
Fix docker-compose issue with pyodbc

### DIFF
--- a/tools/dev-django.sh
+++ b/tools/dev-django.sh
@@ -14,6 +14,7 @@ if [[ ! -f "${venv}/bin/python" ]]; then
 fi
 
 echo "Installing dependencies"
+apt-get update && apt-get install -y g++ unixodbc-dev # pyodbc build dependencies
 "${venv}/bin/pip" install -r "${root}/requirements.txt"
 
 echo "Initializing database"


### PR DESCRIPTION
Fixes #391 

pyodbc [requires g++ and unixodbc-dev](https://github.com/mkleehammer/pyodbc/wiki/Install#debian-stretch).