### PR TITLE
Bugfix/Enable editing of labels with shortcut keys

### DIFF
--- a/app/api/tests/test_api.py
+++ b/app/api/tests/test_api.py
@@ -256,7 +256,9 @@ class TestLabelDetailAPI(APITestCase):
                                                    email='fizz@buzz.com')
         project = mommy.make('Project', users=[project_member, super_user])
         cls.label = mommy.make('Label', project=project)
+        cls.label_with_shortcut = mommy.make('Label', suffix_key='l', project=project)
         cls.url = reverse(viewname='label_detail', args=[project.id, cls.label.id])
+        cls.url_with_shortcut = reverse(viewname='label_detail', args=[project.id, cls.label_with_shortcut.id])
         cls.data = {'text': 'example'}
 
     def test_returns_label_to_project_member(self):
@@ -276,6 +278,12 @@ class TestLabelDetailAPI(APITestCase):
                           password=self.super_user_pass)
         response = self.client.patch(self.url, format='json', data=self.data)
         self.assertEqual(response.data['text'], self.data['text'])
+
+    def test_allows_superuser_to_update_label_with_shortcut(self):
+        self.client.login(username=self.super_user_name,
+                          password=self.super_user_pass)
+        response = self.client.patch(self.url_with_shortcut, format='json', data={'suffix_key': 's'})
+        self.assertEqual(response.data['suffix_key'], 's')
 
     def test_disallows_project_member_to_update_label(self):
         self.client.login(username=self.project_member_name,


### PR DESCRIPTION
As reported in https://github.com/chakki-works/doccano/issues/379, it's currently not possible to edit a label that has a shortcut key set. This is because in the LabelSerializer we're checking if any other label has the same prefix or suffix key as the serialized label:

https://github.com/chakki-works/doccano/blob/55c6cc27abfdd9d8ab8cfc4ef493116519f750c4/app/api/serializers.py#L43-L46

However, if we're editing a label and not changing its prefix or suffix key, the check will always retrieve the currently edited label as a conflict. The solution to this problem implemented in this pull request is to exclude the currently edited label from the check.

Resolves https://github.com/chakki-works/doccano/issues/379