### PR TITLE
Bugfix/Enable superuser to delete user annotations

### DIFF
--- a/app/api/permissions.py
+++ b/app/api/permissions.py
@@ -34,6 +34,9 @@ class ProjectAdminMixin(UserPassesTestMixin):
 class IsOwnAnnotation(ProjectMixin, BasePermission):
 
     def has_permission(self, request, view):
+        if request.user.is_superuser:
+            return True
+
         project_id = self.get_project_id(request, view)
         annotation_id = view.kwargs.get('annotation_id')
         project = get_object_or_404(Project, pk=project_id)

--- a/app/api/tests/test_api.py
+++ b/app/api/tests/test_api.py
@@ -674,12 +674,18 @@ class TestAnnotationDetailAPI(APITestCase):
 
     @classmethod
     def setUpTestData(cls):
+        cls.super_user_name = 'super_user_name'
+        cls.super_user_pass = 'super_user_pass'
         cls.project_member_name = 'project_member_name'
         cls.project_member_pass = 'project_member_pass'
         cls.another_project_member_name = 'another_project_member_name'
         cls.another_project_member_pass = 'another_project_member_pass'
         cls.non_project_member_name = 'non_project_member_name'
         cls.non_project_member_pass = 'non_project_member_pass'
+        # Todo: change super_user to project_admin.
+        super_user = User.objects.create_superuser(username=cls.super_user_name,
+                                                   password=cls.super_user_pass,
+                                                   email='fizz@buzz.com')
         create_default_roles()
         project_member = User.objects.create_user(username=cls.project_member_name,
                                                   password=cls.project_member_pass)
@@ -689,7 +695,7 @@ class TestAnnotationDetailAPI(APITestCase):
                                                       password=cls.non_project_member_pass)
 
         main_project = mommy.make('SequenceLabelingProject',
-                                  users=[project_member, another_project_member])
+                                  users=[super_user, project_member, another_project_member])
         main_project_doc = mommy.make('Document', project=main_project)
         main_project_entity = mommy.make('SequenceAnnotation',
                                          document=main_project_doc, user=project_member)
@@ -745,6 +751,12 @@ class TestAnnotationDetailAPI(APITestCase):
                           password=self.project_member_pass)
         response = self.client.patch(self.another_url, format='json', data=self.post_data)
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+
+    def test_allows_superuser_to_delete_annotation_of_another_member(self):
+        self.client.login(username=self.super_user_name,
+                          password=self.super_user_pass)
+        response = self.client.delete(self.another_url, format='json', data=self.post_data)
+        self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
 
     def test_allows_project_member_to_delete_annotation(self):
         self.client.login(username=self.project_member_name,


### PR DESCRIPTION
As reported in https://github.com/chakki-works/doccano/issues/385, superusers currently can't delete annotations created by another user. This pull request enables superusers to delete annotations even if they were created by another user.

Resolves https://github.com/chakki-works/doccano/issues/385