### PR TITLE
ami id, docker ports, instance type

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ git push heroku master
 
 Doccano can be deployed to AWS ([Cloudformation](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/Welcome.html)) by clicking on the button below:
 
-[![AWS CloudFormation Launch Stack SVG Button](https://cdn.rawgit.com/buildkite/cloudformation-launch-stack-button-svg/master/launch-stack.svg)](https://us-east-1.console.aws.amazon.com/cloudformation/home?region=us-east-1#/stacks/create/review?templateURL=https://s3-external-1.amazonaws.com/cf-templates-10vry9l3mp71r-us-east-1/20190732wl-new.templatexloywxxyimi&stackName=doccano)
+[![AWS CloudFormation Launch Stack SVG Button](https://cdn.rawgit.com/buildkite/cloudformation-launch-stack-button-svg/master/launch-stack.svg)](https://console.aws.amazon.com/cloudformation/home?#/stacks/create/review?stackName=doccano&templateURL=https://s3-external-1.amazonaws.com/cf-templates-10vry9l3mp71r-us-east-1/2019290i9t-AppSGl1poo4j8qpq)
 
 > Notice: (1) EC2 KeyPair cannot be created automatically, so make sure you have an existing EC2 KeyPair in one region. Or [create one yourself](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-key-pairs.html#having-ec2-create-your-key-pair). (2) If you want to access doccano via HTTPS in AWS, here is an [instruction](https://github.com/chakki-works/doccano/wiki/HTTPS-setting-for-doccano-in-AWS).
 

--- a/awsdeploy.yml
+++ b/awsdeploy.yml
@@ -24,8 +24,8 @@ Resources:
   App:
     Type: 'AWS::EC2::Instance'
     Properties:
-      InstanceType: t2.micro
-      ImageId: ami-0ac019f4fcb7cb7e6
+      InstanceType: !Ref InstanceType
+      ImageId: !Ref Ubuntu16Ami
       KeyName: !Ref KeyName
       SecurityGroups:
         - !Ref AppSG
@@ -84,7 +84,7 @@ Resources:
             - |
               sudo docker pull chakkiworks/doccano:latest
             - >
-              sudo docker run -d --name doccano --env-file /env.list -p 80:80
+              sudo docker run -d --name doccano --env-file /env.list -p 80:8000
               chakkiworks/doccano:latest
             - >
               sudo docker exec doccano tools/create-admin.sh ${ADMIN} ${EMAIL}
@@ -92,6 +92,67 @@ Resources:
     Metadata:
       'AWS::CloudFormation::Designer':
         id: 3547c02e-5393-4b26-a9af-6f00dc2cbcdb
+  DescribeImagesRole:
+    Type: AWS::IAM::Role
+    Properties:
+      AssumeRolePolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+          - Action: sts:AssumeRole
+            Effect: Allow
+            Principal:
+              Service: lambda.amazonaws.com
+      ManagedPolicyArns:
+        - arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole
+      Policies:
+        - PolicyName: DescribeImages
+          PolicyDocument:
+            Version: '2012-10-17'
+            Statement:
+              - Action: ec2:DescribeImages
+                Effect: Allow
+                Resource: "*"
+  GetLatestAMI:
+    Type: AWS::Lambda::Function
+    Properties:
+      Runtime: python3.6
+      Handler: index.handler
+      Role: !Sub ${DescribeImagesRole.Arn}
+      Timeout: 60
+      Code:
+        ZipFile: |
+          import boto3
+          import cfnresponse
+          import json
+          import traceback
+
+          def handler(event, context):
+            try:
+              response = boto3.client('ec2').describe_images(
+                  Owners=[event['ResourceProperties']['Owner']],
+                  Filters=[
+                    {'Name': 'name', 'Values': [event['ResourceProperties']['Name']]},
+                    {'Name': 'architecture', 'Values': [event['ResourceProperties']['Architecture']]},
+                    {'Name': 'root-device-type', 'Values': ['ebs']},
+                  ],
+              )
+
+              amis = sorted(response['Images'],
+                            key=lambda x: x['CreationDate'],
+                            reverse=True)
+              id = amis[0]['ImageId']
+
+              cfnresponse.send(event, context, cfnresponse.SUCCESS, {}, id)
+            except:
+              traceback.print_last()
+              cfnresponse.send(event, context, cfnresponse.FAIL, {}, "ok")
+  Ubuntu16Ami:
+    Type: Custom::FindAMI
+    Properties:
+      ServiceToken: !Sub ${GetLatestAMI.Arn}
+      Owner: "099720109477"
+      Name: "ubuntu/images/hvm-ssd/ubuntu-xenial-16.04-amd64-server-20190913"
+      Architecture: "x86_64"
 Metadata:
   'AWS::CloudFormation::Designer':
     116a7f7b-14c5-489a-a3c8-faf276be7ab0:
@@ -124,6 +185,9 @@ Parameters:
       - t2.micro
       - t2.small
       - t2.medium
+      - t3.micro
+      - t3.small
+      - t3.medium
     ConstraintDescription: must be a valid EC2 instance type.
   KeyName:
     Description: Name of an EC2 KeyPair to enable SSH access to the instance.


### PR DESCRIPTION
Changes:

Ami Id:
I made an issue a few weeks ago about the hard coded AMI id.
https://github.com/chakki-works/doccano/issues/397
The documentation was updated but the AMI is still hard coded.
This solution will dynmically pull the correct ubuntu 16 ami id no matter what region you are in.

Docker ports:
Not sure if I am missing something here, but the app serves on port 8000, but the user data in the cfn template maps 80 to 80. So I changed it to map 80 to 8000. It works when I launch it in my AWS account.

Instance type:
The cfn template asks the user to select an instance type. But then it used a hard coded one anyways. So I changed it to use the selected instance type. I assume this was the intended behavior? I also added t3 instance types. Depending on the region you are in, different instance types may or may not be available. It's good to allow users the choice.