### PR TITLE
add download-labels button to download pages

### DIFF
--- a/app/api/tests/test_api.py
+++ b/app/api/tests/test_api.py
@@ -1242,6 +1242,7 @@ class TestDownloader(APITestCase):
         cls.classification_url = reverse(viewname='doc_downloader', args=[cls.classification_project.id])
         cls.labeling_url = reverse(viewname='doc_downloader', args=[cls.labeling_project.id])
         cls.seq2seq_url = reverse(viewname='doc_downloader', args=[cls.seq2seq_project.id])
+        cls.download_labels_url = reverse(viewname='label_downloader', args=[cls.labeling_project.id])
 
     def setUp(self):
         self.client.login(username=self.super_user_name,
@@ -1295,6 +1296,12 @@ class TestDownloader(APITestCase):
         self.download_test_helper(url=self.classification_url,
                                   format='plain',
                                   expected_status=status.HTTP_400_BAD_REQUEST)
+
+    def test_label_download_json(self):
+        self.download_test_helper(url=self.download_labels_url,
+                                  format='json',
+                                  expected_status=status.HTTP_200_OK)
+
 
 
 class TestStatisticsAPI(APITestCase):

--- a/app/api/urls.py
+++ b/app/api/urls.py
@@ -7,7 +7,7 @@ from .views import ProjectList, ProjectDetail
 from .views import LabelList, LabelDetail, ApproveLabelsAPI
 from .views import DocumentList, DocumentDetail
 from .views import AnnotationList, AnnotationDetail
-from .views import TextUploadAPI, TextDownloadAPI, CloudUploadAPI
+from .views import TextUploadAPI, TextDownloadAPI, CloudUploadAPI, LabelDownloadAPI
 from .views import StatisticsAPI
 from .views import RoleMappingList, RoleMappingDetail, Roles
 
@@ -26,6 +26,8 @@ urlpatterns = [
          LabelList.as_view(), name='label_list'),
     path('projects/<int:project_id>/labels/<int:label_id>',
          LabelDetail.as_view(), name='label_detail'),
+    path('projects/<int:project_id>/labels/download',
+         LabelDownloadAPI.as_view(),  name='label_downloader'),
     path('projects/<int:project_id>/docs',
          DocumentList.as_view(), name='doc_list'),
     path('projects/<int:project_id>/docs/<int:doc_id>',

--- a/app/api/views.py
+++ b/app/api/views.py
@@ -318,6 +318,15 @@ class TextDownloadAPI(APIView):
             raise ValidationError('format {} is invalid.'.format(format))
 
 
+class LabelDownloadAPI(APIView):
+    permission_classes = [IsAuthenticated & IsInProjectOrAdmin]
+
+    def get(self, request, *args, **kwargs):
+        project = get_object_or_404(Project, pk=self.kwargs['project_id'])
+        labels = project.labels.all()
+        return Response({"labels": LabelSerializer(labels, many=True).data})
+
+
 class Users(APIView):
     permission_classes = [IsAuthenticated & IsProjectAdmin]
 
@@ -353,12 +362,3 @@ class RoleMappingDetail(generics.RetrieveUpdateDestroyAPIView):
     serializer_class = RoleMappingSerializer
     lookup_url_kwarg = 'rolemapping_id'
     permission_classes = [IsAuthenticated & IsProjectAdmin]
-
-
-class LabelDownloadAPI(APIView):
-    permission_classes = (IsAuthenticated, IsProjectUser, IsAdminUser)
-
-    def get(self, request, *args, **kwargs):
-        project = get_object_or_404(Project, pk=self.kwargs['project_id'])
-        labels = project.labels.all()
-        return Response({"labels": LabelSerializer(labels, many=True).data})

--- a/app/api/views.py
+++ b/app/api/views.py
@@ -353,3 +353,12 @@ class RoleMappingDetail(generics.RetrieveUpdateDestroyAPIView):
     serializer_class = RoleMappingSerializer
     lookup_url_kwarg = 'rolemapping_id'
     permission_classes = [IsAuthenticated & IsProjectAdmin]
+
+
+class LabelDownloadAPI(APIView):
+    permission_classes = (IsAuthenticated, IsProjectUser, IsAdminUser)
+
+    def get(self, request, *args, **kwargs):
+        project = get_object_or_404(Project, pk=self.kwargs['project_id'])
+        labels = project.labels.all()
+        return Response({"labels": LabelSerializer(labels, many=True).data})

--- a/app/server/static/components/download.pug
+++ b/app/server/static/components/download.pug
@@ -30,4 +30,3 @@ div.columns(v-cloak="")
           v-on:click="downloadLabels()"
           v-bind:class="{'is-loading': isLoading}"
         ) Download Labels
-

--- a/app/server/static/components/download.pug
+++ b/app/server/static/components/download.pug
@@ -18,6 +18,16 @@ div.columns(v-cloak="")
         button.button.is-primary(
           style="margin-top: 1em;"
           type="submit"
-          v-on:click="download()"
+          v-on:click="downloadDocs()"
           v-bind:class="{'is-loading': isLoading}"
         ) Download
+
+        hr
+
+        button.button.is-secondary(
+          style="margin-top: 1em;"
+          type="submit"
+          v-on:click="downloadLabels()"
+          v-bind:class="{'is-loading': isLoading}"
+        ) Download Labels
+

--- a/app/server/static/components/uploadMixin.js
+++ b/app/server/static/components/uploadMixin.js
@@ -98,7 +98,7 @@ export default {
       });
     },
 
-    download(download_url, format) {
+    download(downloadUrl, format) {
       this.isLoading = true;
       const headers = {};
       if (format === 'csv') {
@@ -109,7 +109,7 @@ export default {
         headers['Content-Type'] = 'application/json';
       }
       HTTP({
-        url: download_url,
+        url: downloadUrl,
         method: 'GET',
         responseType: 'blob',
         params: {
@@ -131,11 +131,11 @@ export default {
     },
 
     downloadDocs() {
-      this.download('docs/download', this.format)
+      this.download('docs/download', this.format);
     },
 
     downloadLabels() {
-      this.download('labels/download', 'json')
+      this.download('labels/download', 'json');
     },
   },
 };

--- a/app/server/static/components/uploadMixin.js
+++ b/app/server/static/components/uploadMixin.js
@@ -98,10 +98,10 @@ export default {
       });
     },
 
-    download() {
+    download(download_url, format) {
       this.isLoading = true;
       const headers = {};
-      if (this.format === 'csv') {
+      if (format === 'csv') {
         headers.Accept = 'text/csv; charset=utf-8';
         headers['Content-Type'] = 'text/csv; charset=utf-8';
       } else {
@@ -109,18 +109,18 @@ export default {
         headers['Content-Type'] = 'application/json';
       }
       HTTP({
-        url: 'docs/download',
+        url: download_url,
         method: 'GET',
         responseType: 'blob',
         params: {
-          q: this.format,
+          q: format,
         },
         headers,
       }).then((response) => {
         const url = window.URL.createObjectURL(new Blob([response.data]));
         const link = document.createElement('a');
         link.href = url;
-        link.setAttribute('download', 'file.' + this.format); // or any other extension
+        link.setAttribute('download', 'file.' + format); // or any other extension
         document.body.appendChild(link);
         this.isLoading = false;
         link.click();
@@ -128,6 +128,14 @@ export default {
         this.isLoading = false;
         this.handleError(error);
       });
+    },
+
+    downloadDocs() {
+      this.download('docs/download', this.format)
+    },
+
+    downloadLabels() {
+      this.download('labels/download', 'json')
     },
   },
 };


### PR DESCRIPTION
Added a button to the "File Downloader" card that downloads a file containing serialized Label objects. Django's ModelSerializer supports query parameters "format=json" (default) or "format=xml".

Adds a `labels/download` api endpoint:
`http://localhost:8080/v1/projects/1/labels/download?format=json`
`http://localhost:8080/v1/projects/1/labels/download?format=xml`

Adds a “Download Labels” button:
![image](https://user-images.githubusercontent.com/170360/67127285-debbda00-f1ad-11e9-9fde-4ae46a2245e4.png)

