### PR TITLE
Auto-labeling implementation

### DIFF
--- a/app/api/urls.py
+++ b/app/api/urls.py
@@ -8,7 +8,7 @@ from .views import LabelList, LabelDetail, ApproveLabelsAPI
 from .views import DocumentList, DocumentDetail
 from .views import AnnotationList, AnnotationDetail
 from .views import TextUploadAPI, TextDownloadAPI, CloudUploadAPI
-from .views import StatisticsAPI
+from .views import StatisticsAPI, AutoLabelAPI
 
 
 urlpatterns = [
@@ -30,6 +30,8 @@ urlpatterns = [
          DocumentDetail.as_view(), name='doc_detail'),
     path('projects/<int:project_id>/docs/<int:doc_id>/approve-labels',
          ApproveLabelsAPI.as_view(), name='approve_labels'),
+    path('projects/<int:project_id>/docs/<int:doc_id>/auto-label',
+         AutoLabelAPI.as_view(), name='auto_label'),
     path('projects/<int:project_id>/docs/<int:doc_id>/annotations',
          AnnotationList.as_view(), name='annotation_list'),
     path('projects/<int:project_id>/docs/<int:doc_id>/annotations/<int:annotation_id>',

--- a/app/labeling/interactive.py
+++ b/app/labeling/interactive.py
@@ -1,0 +1,79 @@
+# Source : https://github.com/explosion/spaCy/blob/master/examples/training/train_ner.py
+from api.serializers import DocumentSerializer
+import spacy
+from spacy.util import minibatch, compounding
+import random
+
+
+class ProjectInteraction(object):
+
+    def auto_label_documents(self, queryset, project, user_id):
+        if project.get_bundle_name() == 'sequence_labeling':
+            return self.auto_label_seq_labeling(queryset, project, user_id)
+        if project.get_bundle_name() == 'document_classification':
+            return self.auto_label_document_classification(queryset, project, user_id)
+        else:
+            return []
+
+    def auto_label_document_classification(self, queryset, project, user_id):
+        print('auto labeling not implemented yet for doc classification')
+        return []
+
+    def auto_label_seq_labeling(self, queryset, project, user_id):
+        """ Auto labeling for sequence labeling projects based on spaCy's
+        multi-language ner
+        """
+        labelled_data = DocumentSerializer(queryset.exclude(annotations_approved_by=None), many=True).data
+        unlabelled_data = DocumentSerializer(queryset.filter(annotations_approved_by=None), many=True).data
+        labels = project.labels.all()
+
+        nlp = spacy.load("xx_ent_wiki_sm")
+        nlp.remove_pipe('ner')
+        ner = nlp.create_pipe('ner')
+        nlp.add_pipe(ner, last=True)
+
+        labels_id2txt = {}
+        labels_txt2label = {}
+        for i in range(len(labels)):
+            ner.add_label(labels[i].text)
+            labels_id2txt[labels[i].id] = labels[i].text
+            labels_txt2label[labels[i].text] = labels[i]
+
+        train_data = []
+        for item in labelled_data:
+            doc = str(nlp.make_doc(item['text']))
+            entities = [(x['start_offset'], x['end_offset'], labels_id2txt[x['label']]) for x in item['annotations']]
+            train_data.append((doc, {"entities": entities}))
+
+        other_pipes = [pipe for pipe in nlp.pipe_names if pipe != "ner"]
+        with nlp.disable_pipes(*other_pipes):
+            sizes = compounding(1.0, 4.0, 1.001)
+            optimizer = nlp.begin_training()
+            for itn in range(20):
+                random.shuffle(train_data)
+                batches = minibatch(train_data, size=sizes)
+                losses = {}
+                for batch in batches:
+                    texts, annotations = zip(*batch)
+                    nlp.update(texts, annotations, sgd=optimizer, drop=0.35, losses=losses)
+                print("Losses", losses)
+
+        new_data = []
+        for item in unlabelled_data:
+            doc = str(nlp.make_doc(item['text']))
+            entities = [(x['start_offset'], x['end_offset'], labels_id2txt[x['label']]) for x in item['annotations']]
+            new_data.append((doc, {"entities": entities}))
+
+        new_sent_annotations = []
+        for new, document in zip(new_data, queryset.filter(annotations_approved_by=None)):
+            text, _ = new
+            doc = nlp(text)
+            new_annotations = [(ent.text, ent.label_, ent.start_char, ent.end_char) for ent in doc.ents]
+            for new in new_annotations:
+                new_sent_annotations.append({'document': document,
+                                             'label': labels_txt2label[new[1]],
+                                             'start_offset': new[2],
+                                             'end_offset': new[3],
+                                             'user_id': user_id})
+
+        return new_sent_annotations

--- a/app/server/static/components/annotation.pug
+++ b/app/server/static/components/annotation.pug
@@ -64,7 +64,7 @@ div.columns(v-cloak="")
           href="#"
         )
           span.icon
-            i.fa.fa-check(v-show="annotations[index] && annotations[index].length")
+            i.fa.fa-check(v-show="doc.annotation_approver !== null")
           span.name {{ doc.text.slice(0, 60) }}...
 
   div.column.is-7.is-offset-1.message.hero.is-fullheight#message-pane
@@ -106,12 +106,12 @@ div.columns(v-cloak="")
           v-bind:value="achievement"
           max="100"
         ) 30%
-      div.column.is-6
+      div.column.is-5
         span.ml10
           strong {{ total - remaining }}
         | /
         span {{ total }}
-
+        
       div.column.is-1.has-text-right
         a.button.tooltip.is-tooltip-bottom(
           v-if="isSuperuser"
@@ -120,6 +120,14 @@ div.columns(v-cloak="")
         )
           span.icon
             i.far(v-bind:class="[documentAnnotationsAreApproved ? 'fa-check-circle' : 'fa-circle']")
+      div.column.is-1.has-text-right
+        a.button.tooltip.is-tooltip-bottom(
+          v-if="isSuperuser"
+          v-on:click="runAutoLabeling"
+          v-bind:data-tooltip="autoLabelTooltip"
+        )
+          span.icon
+            i.fas.fa-robot
       div.column.is-1.has-text-right
         a.button(v-on:click="isAnnotationGuidelineActive = !isAnnotationGuidelineActive")
           span.icon

--- a/app/server/static/components/annotationMixin.js
+++ b/app/server/static/components/annotationMixin.js
@@ -227,6 +227,12 @@ export default {
         this.docs = documents;
       });
     },
+  runAutoLabeling() {
+    const document = this.docs[this.pageNumber];
+    HTTP.get(`docs/${document.id}/auto-label`).then((response) => {
+      this.submit();
+    });
+  },
   },
 
   watch: {
@@ -284,6 +290,10 @@ export default {
       return this.documentAnnotationsAreApproved
         ? `Annotations approved by ${document.annotation_approver}, click to reject annotations`
         : 'Click to approve annotations';
+    },
+
+    autoLabelTooltip() {
+      return 'Remove unapproved annotations and suggests new ones';
     },
 
     documentMetadata() {

--- a/requirements.txt
+++ b/requirements.txt
@@ -41,3 +41,5 @@ vcrpy==2.0.1
 vcrpy-unittest==0.1.7
 whitenoise[brotli]==4.1.2
 conllu==1.3.2
+spacy>=2.2.0
+https://github.com/explosion/spacy-models/releases/download/xx_ent_wiki_sm-2.1.0/xx_ent_wiki_sm-2.1.0.tar.gz


### PR DESCRIPTION
Implementation of a solution for auto-labeling (sequence labelling projects only) as discussed in https://github.com/chakki-works/doccano/issues/191

- Solution based on spaCy’s ner module (multi-language)

- New button that allows an admin to start auto-labeling (and removes unapproved annotations)

- For now, if a document has no annotation, it will never be described as ‘validated’. I propose  an other way to define a document as ‘validated’ : a document is ‘validated' when it has been approved by an admin. I changed this behaviour because otherwise we couldn’t differentiate documents labeled automatically from others. 


Possible improvements :

- Add a shortcut to quickly validate one document (Enter?)

- Currently, the labels suggested by the algorithm are saved as if they were done by the admin clicking on the button; so a ‘normal’ user can’t change it. It would be better to add these new labels as if they were done by an other user (named ‘computer' for example)