### PR TITLE
Feature/label nonfield error messages

### DIFF
--- a/app/server/static/components/label.vue
+++ b/app/server/static/components/label.vue
@@ -263,7 +263,7 @@ export default {
           this.messages = [];
         })
         .catch((error) => {
-          console.log(error);
+          console.log(error); // eslint-disable-line no-console
           if (error.response.data.non_field_errors) {
             error.response.data.non_field_errors.forEach((msg) => {
               this.messages.push(msg);

--- a/app/server/static/components/label.vue
+++ b/app/server/static/components/label.vue
@@ -263,8 +263,14 @@ export default {
           this.messages = [];
         })
         .catch((error) => {
-          console.log(error); // eslint-disable-line no-console
-          this.messages.push('You cannot use same label name or shortcut key.');
+          console.log(error);
+          if (error.response.data.non_field_errors) {
+            error.response.data.non_field_errors.forEach((msg) => {
+              this.messages.push(msg);
+            });
+          } else {
+            this.messages.push('You cannot use same label name or shortcut key.');
+          }
         });
     },
 
@@ -312,7 +318,13 @@ export default {
         })
         .catch((error) => {
           console.log(error); // eslint-disable-line no-console
-          this.messages.push('You cannot use same label name or shortcut key.');
+          if (error.response.data.non_field_errors) {
+            error.response.data.non_field_errors.forEach((msg) => {
+              this.messages.push(msg);
+            });
+          } else {
+            this.messages.push('You cannot use same label name or shortcut key.');
+          }
         });
     },
 


### PR DESCRIPTION
Currently any error raised during label creation or editing will result in a standardised message relating to duplicate names or shortcut keys, however, this is inaccurate as other potential issues exist (e.g. the shortcut combination not having a suffix). This change will push an appropriate error message in such situations. 

Any feedback is welcome.