### PR TITLE
Enhancement/Add guest user role

### DIFF
--- a/app/api/models.py
+++ b/app/api/models.py
@@ -299,14 +299,10 @@ def add_superusers_to_project(sender, instance, created, **kwargs):
 
 @receiver(post_save, sender=User)
 def add_new_superuser_to_projects(sender, instance, created, **kwargs):
-    if created and instance.is_superuser:
-        admin_role = Role.objects.filter(name=settings.ROLE_PROJECT_ADMIN).first()
-        projects = Project.objects.all()
-        if admin_role and projects:
-            RoleMapping.objects.bulk_create(
-                [RoleMapping(role_id=admin_role.id, user_id=instance.id, project_id=project.id)
-                 for project in projects]
-            )
+    from .permissions import add_superuser_to_all_projects
+
+    if created:
+        add_superuser_to_all_projects(instance)
 
 
 @receiver(pre_delete, sender=RoleMapping)

--- a/app/api/permissions.py
+++ b/app/api/permissions.py
@@ -68,6 +68,10 @@ class IsProjectAdmin(RolePermission):
     role_name = settings.ROLE_PROJECT_ADMIN
 
 
+class IsViewerAndReadOnly(RolePermission):
+    role_name = settings.ROLE_VIEWER
+
+
 class IsAnnotatorAndReadOnly(RolePermission):
     role_name = settings.ROLE_ANNOTATOR
 

--- a/app/api/views.py
+++ b/app/api/views.py
@@ -15,15 +15,15 @@ from rest_framework_csv.renderers import CSVRenderer
 
 from .filters import DocumentFilter
 from .models import Project, Label, Document, RoleMapping, Role
-from .permissions import IsProjectAdmin, IsAnnotatorAndReadOnly, IsAnnotator, IsAnnotationApproverAndReadOnly, IsOwnAnnotation, IsAnnotationApprover
+from .permissions import IsAnnotatorAndReadOnly, IsAnnotationApproverAndReadOnly, IsViewerAndReadOnly
+from .permissions import IsProjectAdmin, IsAnnotator, IsAnnotationApprover, IsOwnAnnotation
 from .serializers import ProjectSerializer, LabelSerializer, DocumentSerializer, UserSerializer
 from .serializers import ProjectPolymorphicSerializer, RoleMappingSerializer, RoleSerializer
 from .utils import CSVParser, ExcelParser, JSONParser, PlainTextParser, CoNLLParser, iterable_to_io
 from .utils import JSONLRenderer
 from .utils import JSONPainter, CSVPainter
 
-IsInProjectReadOnlyOrAdmin = (IsAnnotatorAndReadOnly | IsAnnotationApproverAndReadOnly | IsProjectAdmin)
-IsInProjectOrAdmin = (IsAnnotator | IsAnnotationApprover | IsProjectAdmin)
+IsInProjectReadOnlyOrAdmin = (IsViewerAndReadOnly | IsAnnotatorAndReadOnly | IsAnnotationApproverAndReadOnly | IsProjectAdmin)
 
 
 class Me(APIView):
@@ -155,7 +155,7 @@ class DocumentDetail(generics.RetrieveUpdateDestroyAPIView):
 
 class AnnotationList(generics.ListCreateAPIView):
     pagination_class = None
-    permission_classes = [IsAuthenticated & IsInProjectOrAdmin]
+    permission_classes = [IsAuthenticated & (IsAnnotator | IsAnnotationApprover | IsProjectAdmin | IsViewerAndReadOnly)]
 
     def get_serializer_class(self):
         project = get_object_or_404(Project, pk=self.kwargs['project_id'])
@@ -183,7 +183,7 @@ class AnnotationList(generics.ListCreateAPIView):
 
 class AnnotationDetail(generics.RetrieveUpdateDestroyAPIView):
     lookup_url_kwarg = 'annotation_id'
-    permission_classes = [IsAuthenticated & (((IsAnnotator | IsAnnotationApprover) & IsOwnAnnotation) | IsProjectAdmin)]
+    permission_classes = [IsAuthenticated & (((IsAnnotator | IsAnnotationApprover) & IsOwnAnnotation) | IsProjectAdmin | IsViewerAndReadOnly)]
 
     def get_serializer_class(self):
         project = get_object_or_404(Project, pk=self.kwargs['project_id'])

--- a/app/app/settings.py
+++ b/app/app/settings.py
@@ -178,6 +178,7 @@ SOCIAL_AUTH_PIPELINE = [
 ROLE_PROJECT_ADMIN = env('ROLE_PROJECT_ADMIN', 'project_admin')
 ROLE_ANNOTATOR = env('ROLE_ANNOTATOR', 'annotator')
 ROLE_ANNOTATION_APPROVER = env('ROLE_ANNOTATION_APPROVER', 'annotation_approver')
+ROLE_VIEWER = env('ROLE_VIEWER', 'viewer')
 
 # Database
 # https://docs.djangoproject.com/en/2.0/ref/settings/#databases

--- a/app/server/management/commands/create_roles.py
+++ b/app/server/management/commands/create_roles.py
@@ -11,7 +11,12 @@ class Command(BaseCommand):
 
     def handle(self, *args, **options):
         try:
-            role_names = [settings.ROLE_PROJECT_ADMIN, settings.ROLE_ANNOTATOR, settings.ROLE_ANNOTATION_APPROVER]
+            role_names = [
+                settings.ROLE_PROJECT_ADMIN,
+                settings.ROLE_ANNOTATOR,
+                settings.ROLE_ANNOTATION_APPROVER,
+                settings.ROLE_VIEWER,
+            ]
         except KeyError as key_error:
             self.stderr.write(self.style.ERROR(f'Missing Key: "{key_error}"'))
             return

--- a/app/server/management/commands/create_roles.py
+++ b/app/server/management/commands/create_roles.py
@@ -1,7 +1,9 @@
-from api.models import Role
 from django.core.management.base import BaseCommand
 from django.db import DatabaseError
 from django.conf import settings
+
+from api.models import Role, User
+from api.permissions import add_superuser_to_all_projects
 
 
 class Command(BaseCommand):
@@ -12,12 +14,15 @@ class Command(BaseCommand):
             role_names = [settings.ROLE_PROJECT_ADMIN, settings.ROLE_ANNOTATOR, settings.ROLE_ANNOTATION_APPROVER]
         except KeyError as key_error:
             self.stderr.write(self.style.ERROR(f'Missing Key: "{key_error}"'))
+            return
+
         for role_name in role_names:
-            role = Role()
-            role.name = role_name
+            role = Role(name=role_name)
             try:
                 role.save()
             except DatabaseError as db_error:
-                self.stderr.write(self.style.ERROR(f'Datbase Error: "{db_error}"'))
+                self.stderr.write(self.style.ERROR(f'Database Error: "{db_error}"'))
             else:
                 self.stdout.write(self.style.SUCCESS(f'Role created successfully "{role_name}"'))
+
+        add_superuser_to_all_projects(*list(User.objects.filter(is_superuser=True)))

--- a/tools/dev-django.sh
+++ b/tools/dev-django.sh
@@ -20,7 +20,6 @@ apt-get update && apt-get install -y g++ unixodbc-dev # pyodbc build dependencie
 echo "Initializing database"
 "${venv}/bin/python" "${app}/manage.py" wait_for_db
 "${venv}/bin/python" "${app}/manage.py" migrate
-"${venv}/bin/python" "${app}/manage.py" create_roles
 
 if [[ -n "${ADMIN_USERNAME}" ]] && [[ -n "${ADMIN_PASSWORD}" ]] && [[ -n "${ADMIN_EMAIL}" ]]; then
   "${venv}/bin/python" "${app}/manage.py" create_admin \
@@ -30,6 +29,8 @@ if [[ -n "${ADMIN_USERNAME}" ]] && [[ -n "${ADMIN_PASSWORD}" ]] && [[ -n "${ADMI
     --noinput \
   || true
 fi
+
+"${venv}/bin/python" "${app}/manage.py" create_roles
 
 echo "Starting django"
 "${venv}/bin/python" -u "${app}/manage.py" runserver "$@"

--- a/tools/run.sh
+++ b/tools/run.sh
@@ -6,10 +6,11 @@ if [[ ! -d "app/staticfiles" ]]; then python app/manage.py collectstatic --noinp
 
 python app/manage.py wait_for_db
 python app/manage.py migrate
-python app/manage.py create_roles
 
 if [[ -n "${ADMIN_USERNAME}" ]] && [[ -n "${ADMIN_EMAIL}" ]] && [[ -n "${ADMIN_PASSWORD}" ]]; then
   python app/manage.py create_admin --noinput --username="${ADMIN_USERNAME}" --email="${ADMIN_EMAIL}" --password="${ADMIN_PASSWORD}"
 fi
+
+python app/manage.py create_roles
 
 gunicorn --bind="0.0.0.0:${PORT:-8000}" --workers="${WORKERS:-1}" --pythonpath=app app.wsgi --timeout 300


### PR DESCRIPTION
This pull request adds a "guest" or "view only" role to doccano that enables viewing of project documents and annotations but not creation or modification thereof.

The pull request also fixes a number of additional minor issues related to RBAC:

1. The `add_new_superuser_to_projects` functions which grants all superusers the admin role on projects wasn't being exercised for admins that were created before the RBAC functionality was introduced. To backport the RBAC functionality to old instances of doccano, the functionality is now being called on server start when we create the default project roles.

2. The `get_current_users_role` function had a hard-coded list of roles. To make it easier to add new roles in the future, the function has been refactored to dynamically look up all roles.

Resolves https://github.com/chakki-works/doccano/issues/413