### PR TITLE
Enhancement/Add volume for SQLite DB in doccano container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -48,11 +48,17 @@ RUN /doccano/tools/install-mssql.sh
 
 RUN useradd -ms /bin/sh doccano
 
+RUN mkdir /data \
+ && chown doccano:doccano /data
+
 COPY --from=builder /deps /deps
 # hadolint ignore=DL3013
 RUN pip install --no-cache-dir /deps/*.whl
 
 COPY --from=cleaner --chown=doccano:doccano /doccano /doccano
+
+VOLUME /data
+ENV DATABASE_URL="sqlite:////data/doccano.db"
 
 ENV DEBUG="True"
 ENV SECRET_KEY="change-me-in-production"

--- a/README.md
+++ b/README.md
@@ -60,14 +60,25 @@ git clone https://github.com/chakki-works/doccano.git --config core.autocrlf=inp
 
 ### Docker
 
+As a one-time setup, create a Docker container for Doccano:
+
 ```bash
-$ docker pull chakkiworks/doccano
-$ docker run -d --rm --name doccano \
-   -e "ADMIN_USERNAME=admin" \
-   -e "ADMIN_EMAIL=admin@example.com" \
-   -e "ADMIN_PASSWORD=password" \
-   -p 8000:8000 chakkiworks/doccano
+docker pull chakkiworks/doccano
+docker container create --name doccano \
+  -e "ADMIN_USERNAME=admin" \
+  -e "ADMIN_EMAIL=admin@example.com" \
+  -e "ADMIN_PASSWORD=password" \
+  -p 8000:8000 chakkiworks/doccano
 ```
+
+Next, start Doccano by running the container:
+
+```bash
+docker container start doccano
+```
+
+To stop the container, run `docker container stop doccano -t 5`.
+All data created in the container will persist across restarts.
 
 Access <http://127.0.0.1:8000/>.
 


### PR DESCRIPTION
This pull request moves the SQLite database file used in Doccano's Dockerfile to a dedicated directory `/data` and binds this directory using a [VOLUME instruction](https://docs.docker.com/engine/reference/builder/#volume).

This enables us to persist Doccano's database file across container restarts in a filesystem/platform independent way. The README has been updated with instructions on how to leverage this functionality.

Resolves https://github.com/chakki-works/doccano/issues/438
