### PR TITLE
Add project creation options in new frontend

### DIFF
--- a/frontend/components/organisms/projects/ProjectCreationForm.vue
+++ b/frontend/components/organisms/projects/ProjectCreationForm.vue
@@ -38,6 +38,14 @@
           data-test="project-type"
           required
         />
+        <v-checkbox
+          v-model="enableRandomizeDocOrder"
+          label="Randomize document order"
+        />
+        <v-checkbox
+          v-model="enableShareAnnotation"
+          label="Share annotations across all users"
+        />
       </v-form>
     </template>
   </base-card>
@@ -72,6 +80,8 @@ export default {
       name: '',
       description: '',
       projectType: null,
+      enableShareAnnotation: false,
+      enableRandomizeDocOrder: false,
       projectNameRules,
       projectTypeRules,
       descriptionRules
@@ -113,9 +123,9 @@ export default {
           description: this.description,
           project_type: this.getServerType(),
           guideline: 'Please write annotation guideline.',
-          resourcetype: this.getResourceType()
-          // randomize_document_order: this.randomizeDocumentOrder,
-          // collaborative_annotation: this.collaborativeAnnotation
+          resourcetype: this.getResourceType(),
+          randomize_document_order: this.enableRandomizeDocOrder,
+          collaborative_annotation: this.enableShareAnnotation
         })
         this.reset()
         this.cancel()


### PR DESCRIPTION
In ver 1.0.0, I forgot to implement two options: randomize document order and share annotations across all users.

![image](https://user-images.githubusercontent.com/6737785/69202981-8601a780-0b86-11ea-8028-036428d44b57.png)
