### PR TITLE
Fix error on first annotation page open

### DIFF
--- a/frontend/store/pagination.js
+++ b/frontend/store/pagination.js
@@ -29,7 +29,7 @@ export const mutations = {
     localStorage.setItem('checkpoint', JSON.stringify(checkpoint))
   },
   loadPage(state) {
-    const checkpoint = JSON.parse(localStorage.getItem('checkpoint'))
+    const checkpoint = JSON.parse(localStorage.getItem('checkpoint')) || {}
     state.page = checkpoint[state.projectId] ? checkpoint[state.projectId] : 1
   },
   setProjectId(state, projectId) {


### PR DESCRIPTION
At first `checkpoint` localStorage entry does not exist, so
`checkpoint` variable ends up to be `null`.